### PR TITLE
feat: enable GPU backend for LLM inference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ The RAG pipeline (`RagPipeline.kt`) manages three main components:
 2. **Embeddings**: Gecko embedding model for semantic search
    - Model: `Gecko_1024_quant.tflite` (768-dim embeddings)
    - Tokenizer: `sentencepiece.model`
-   - Always CPU (`use_gpu_for_embeddings: false` in `app_config.json`)
+   - CPU by default (`use_gpu_for_embeddings: false` in `app_config.json`)
 
 3. **Vector Store**: SQLite-backed semantic memory
    - Database: `embeddings.sqlite` (pre-computed document embeddings)
@@ -144,7 +144,7 @@ The RAG prompt is defined in `RagPipeline.kt:205-225`. It emphasizes:
 ### Backend Selection
 
 - **LLM**: defaults to CPU in production. Controlled by the `USE_GPU_FOR_LLM` `BuildConfig` field, set at compile time via the Gradle property `useGpuForLlm` (default `false`). If GPU init fails at runtime, `RagPipeline.kt` automatically falls back to CPU.
-- **Embeddings**: always CPU (`use_gpu_for_embeddings: false` in `config/app_config.json`).
+- **Embeddings**: CPU by default (`use_gpu_for_embeddings: false` in `config/app_config.json`).
 
 **To enable GPU locally** (e.g. for latency testing on a capable device), add to `~/.gradle/gradle.properties`:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,13 @@ The RAG pipeline (`RagPipeline.kt`) manages three main components:
 
 1. **LLM Backend**: LiteRT-LM Gemma 4 E4B inference
    - Model: `gemma-4-E4B-it.litertlm` (int4 quantized, 3.65 GB)
-   - Runs on CPU
+   - CPU by default; GPU opt-in via `useGpuForLlm` Gradle property (see Backend Selection)
    - Max tokens: 4096
 
 2. **Embeddings**: Gecko embedding model for semantic search
    - Model: `Gecko_1024_quant.tflite` (768-dim embeddings)
    - Tokenizer: `sentencepiece.model`
-   - Runs on CPU (`USE_GPU_FOR_EMBEDDINGS = false`)
+   - Always CPU (`use_gpu_for_embeddings: false` in `app_config.json`)
 
 3. **Vector Store**: SQLite-backed semantic memory
    - Database: `embeddings.sqlite` (pre-computed document embeddings)
@@ -143,9 +143,14 @@ The RAG prompt is defined in `RagPipeline.kt:205-225`. It emphasizes:
 
 ### Backend Selection
 
-Both LLM and embeddings use **CPU backend** (not GPU). Change in `RagPipeline.kt`:
-- LiteRT-LM backend: configured via `LlmInferenceOptions` in `RagPipeline.kt`
-- Embeddings GPU: `USE_GPU_FOR_EMBEDDINGS = false`
+- **LLM**: defaults to CPU in production. Controlled by the `USE_GPU_FOR_LLM` `BuildConfig` field, set at compile time via the Gradle property `useGpuForLlm` (default `false`). If GPU init fails at runtime, `RagPipeline.kt` automatically falls back to CPU.
+- **Embeddings**: always CPU (`use_gpu_for_embeddings: false` in `config/app_config.json`).
+
+**To enable GPU locally** (e.g. for latency testing on a capable device), add to `~/.gradle/gradle.properties`:
+```
+useGpuForLlm=true
+```
+Or pass it at build time: `flutter build apk -PuseGpuForLlm=true`. Do not commit this flag — production APKs ship with CPU by default until GPU support is validated across target devices.
 
 ### Retrieval Parameters
 

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -13,12 +13,7 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
-val localProperties = Properties()
-val localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.inputStream().use { localProperties.load(it) }
-}
-val useGpuForLlm = localProperties.getProperty("useGpuForLlm", "false").toBoolean()
+val useGpuForLlm = (project.findProperty("useGpuForLlm") as String?)?.toBoolean() ?: false
 
 fun propOrEnv(envName: String, propertyName: String): String? =
     System.getenv(envName)?.takeIf { it.isNotBlank() }

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-        buildConfigField("Boolean", "USE_GPU_FOR_LLM", useGpuForLlm.toString())
+        buildConfigField("boolean", "USE_GPU_FOR_LLM", useGpuForLlm.toString())
     }
 
     sourceSets {

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -96,7 +96,7 @@ kotlin {
 }
 dependencies {
     implementation("com.google.ai.edge.localagents:localagents-rag:0.2.0")
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.0")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.10.2")
     implementation("com.google.protobuf:protobuf-javalite:3.25.4")
 }

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -13,6 +13,13 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.inputStream().use { localProperties.load(it) }
+}
+val useGpuForLlm = localProperties.getProperty("useGpuForLlm", "false").toBoolean()
+
 fun propOrEnv(envName: String, propertyName: String): String? =
     System.getenv(envName)?.takeIf { it.isNotBlank() }
         ?: (keystoreProperties.getProperty(propertyName)?.takeIf { it.isNotBlank() })
@@ -49,6 +56,7 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        buildConfigField("Boolean", "USE_GPU_FOR_LLM", useGpuForLlm.toString())
     }
 
     sourceSets {

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
-val useGpuForLlm = (project.findProperty("useGpuForLlm") as String?)?.toBoolean() ?: false
+val useGpuForLlm = project.findProperty("useGpuForLlm")?.toString()?.toBoolean() ?: false
 
 fun propOrEnv(envName: String, propertyName: String): String? =
     System.getenv(envName)?.takeIf { it.isNotBlank() }

--- a/app/android/app/local.properties
+++ b/app/android/app/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Jul 21 11:41:38 CEST 2025
-sdk.dir=C\:\\Users\\caelm\\AppData\\Local\\Android\\Sdk

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,11 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- Required for LiteRT-LM GPU backend (OpenCL). required="false" allows
+             graceful fallback to OpenGL on devices without OpenCL support. -->
+        <uses-native-library android:name="libOpenCL.so" android:required="false"/>
+        <uses-native-library android:name="libvndksupport.so" android:required="false"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -62,8 +62,9 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <!-- Required for LiteRT-LM GPU backend (OpenCL). required="false" allows
-             graceful fallback to OpenGL on devices without OpenCL support. -->
+        <!-- Optional native libraries for the LiteRT-LM GPU backend (OpenCL).
+             required="false" avoids install-time rejection on devices without
+             these libraries; runtime fallback to CPU is handled in RagPipeline. -->
         <uses-native-library android:name="libOpenCL.so" android:required="false"/>
         <uses-native-library android:name="libvndksupport.so" android:required="false"/>
     </application>

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -97,26 +97,20 @@ class RagPipeline(application: Application) {
                 val useGpu = BuildConfig.USE_GPU_FOR_LLM
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
-                try {
-                    val backend = if (useGpu) {
+                val backend = if (useGpu) {
+                    try {
                         Log.i("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
                         Backend.GPU()
-                    } else {
-                        Log.i("mam-ai", "[BACKEND] Using CPU backend for LLM")
+                    } catch (gpuError: Throwable) {
+                        Log.w("mam-ai", "[BACKEND] WARNING: GPU backend unavailable, falling back to CPU", gpuError)
+                        activeBackend = "CPU"
                         Backend.CPU()
                     }
-                    buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
-                } catch (gpuError: Throwable) {
-                    if (!useGpu) throw gpuError
-                    Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed, falling back to CPU", gpuError)
-                    activeBackend = "CPU"
-                    try {
-                        buildEngine(baseFolder + appConfig.getString("llm_model"), Backend.CPU(), application.cacheDir.path)
-                    } catch (cpuError: Throwable) {
-                        cpuError.addSuppressed(gpuError)
-                        throw cpuError
-                    }
+                } else {
+                    Log.i("mam-ai", "[BACKEND] Using CPU backend for LLM")
+                    Backend.CPU()
                 }
+                buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
                 Log.w("mam-ai", "[BACKEND] *** LLM running on $activeBackend ***")
                 Log.i("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
                 val rt = Runtime.getRuntime()

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -94,15 +94,38 @@ class RagPipeline(application: Application) {
     init {
         Executors.newSingleThreadExecutor().execute {
             try {
+                val useGpu = appConfig.optBoolean("use_gpu_for_llm", false)
+                val backend = if (useGpu) {
+                    Log.w("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
+                    Backend.GPU()
+                } else {
+                    Log.w("mam-ai", "[BACKEND] Using CPU backend for LLM")
+                    Backend.CPU()
+                }
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
-                engine = Engine(
-                    EngineConfig(
-                        modelPath = baseFolder + appConfig.getString("llm_model"),
-                        backend = Backend.CPU(),
-                        cacheDir = application.cacheDir.path,
+                try {
+                    engine = Engine(
+                        EngineConfig(
+                            modelPath = baseFolder + appConfig.getString("llm_model"),
+                            backend = backend,
+                            cacheDir = application.cacheDir.path,
+                        )
                     )
-                )
-                engine.initialize()
+                    engine.initialize()
+                    Log.w("mam-ai", "[BACKEND] ${if (useGpu) "GPU" else "CPU"} backend initialized successfully")
+                } catch (gpuError: Throwable) {
+                    if (!useGpu) throw gpuError
+                    Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed (${gpuError.message}), falling back to CPU")
+                    engine = Engine(
+                        EngineConfig(
+                            modelPath = baseFolder + appConfig.getString("llm_model"),
+                            backend = Backend.CPU(),
+                            cacheDir = application.cacheDir.path,
+                        )
+                    )
+                    engine.initialize()
+                    Log.w("mam-ai", "[BACKEND] CPU fallback initialized successfully")
+                }
                 Log.w("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
                 val rt = Runtime.getRuntime()
                 Log.w("mam-ai", "[MEMORY] post-init heap: ${rt.totalMemory() / 1024 / 1024}MB used, ${rt.freeMemory() / 1024 / 1024}MB free, ${rt.maxMemory() / 1024 / 1024}MB max")

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -94,8 +94,8 @@ class RagPipeline(application: Application) {
     init {
         Executors.newSingleThreadExecutor().execute {
             try {
-                val useGpu = appConfig.optBoolean("use_gpu_for_llm", false)
-                Log.i("mam-ai", "[TIMING] Engine.initialize() starting...")
+                val useGpu = BuildConfig.USE_GPU_FOR_LLM || appConfig.optBoolean("use_gpu_for_llm", false)
+                Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
                 try {
                     val backend = if (useGpu) {

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -97,6 +97,8 @@ class RagPipeline(application: Application) {
                 val useGpu = BuildConfig.USE_GPU_FOR_LLM
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
+                val modelPath = baseFolder + appConfig.getString("llm_model")
+                val cacheDir = application.cacheDir.path
                 val backend = if (useGpu) {
                     try {
                         Log.i("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
@@ -112,14 +114,14 @@ class RagPipeline(application: Application) {
                 }
                 if (useGpu && activeBackend == "GPU") {
                     try {
-                        buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                        buildEngine(modelPath, backend, cacheDir)
                     } catch (gpuInitError: Throwable) {
                         Log.w("mam-ai", "[BACKEND] WARNING: GPU engine init failed, falling back to CPU", gpuInitError)
                         activeBackend = "CPU"
-                        buildEngine(baseFolder + appConfig.getString("llm_model"), Backend.CPU(), application.cacheDir.path)
+                        buildEngine(modelPath, Backend.CPU(), cacheDir)
                     }
                 } else {
-                    buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                    buildEngine(modelPath, backend, cacheDir)
                 }
                 Log.w("mam-ai", "[BACKEND] *** LLM running on $activeBackend ***")
                 Log.i("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -309,8 +309,9 @@ class RagPipeline(application: Application) {
         }
 
     private fun buildEngine(modelPath: String, backend: Backend, cacheDir: String) {
-        engine = Engine(EngineConfig(modelPath = modelPath, backend = backend, cacheDir = cacheDir))
-        engine.initialize()
+        val e = Engine(EngineConfig(modelPath = modelPath, backend = backend, cacheDir = cacheDir))
+        e.initialize()
+        engine = e
     }
 
     companion object {

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -95,16 +95,16 @@ class RagPipeline(application: Application) {
         Executors.newSingleThreadExecutor().execute {
             try {
                 val useGpu = appConfig.optBoolean("use_gpu_for_llm", false)
-                val backend = if (useGpu) {
-                    Log.w("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
-                    Backend.GPU()
-                } else {
-                    Log.w("mam-ai", "[BACKEND] Using CPU backend for LLM")
-                    Backend.CPU()
-                }
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
                 try {
+                    val backend = if (useGpu) {
+                        Log.w("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
+                        Backend.GPU()
+                    } else {
+                        Log.w("mam-ai", "[BACKEND] Using CPU backend for LLM")
+                        Backend.CPU()
+                    }
                     engine = Engine(
                         EngineConfig(
                             modelPath = baseFolder + appConfig.getString("llm_model"),
@@ -113,9 +113,9 @@ class RagPipeline(application: Application) {
                         )
                     )
                     engine.initialize()
-                } catch (gpuError: Throwable) {
+                } catch (gpuError: Exception) {
                     if (!useGpu) throw gpuError
-                    Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed (${gpuError.message}), falling back to CPU")
+                    Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed, falling back to CPU", gpuError)
                     activeBackend = "CPU"
                     engine = Engine(
                         EngineConfig(

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -103,6 +103,7 @@ class RagPipeline(application: Application) {
                     Backend.CPU()
                 }
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
+                var activeBackend = if (useGpu) "GPU" else "CPU"
                 try {
                     engine = Engine(
                         EngineConfig(
@@ -112,10 +113,10 @@ class RagPipeline(application: Application) {
                         )
                     )
                     engine.initialize()
-                    Log.w("mam-ai", "[BACKEND] ${if (useGpu) "GPU" else "CPU"} backend initialized successfully")
                 } catch (gpuError: Throwable) {
                     if (!useGpu) throw gpuError
                     Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed (${gpuError.message}), falling back to CPU")
+                    activeBackend = "CPU"
                     engine = Engine(
                         EngineConfig(
                             modelPath = baseFolder + appConfig.getString("llm_model"),
@@ -124,8 +125,8 @@ class RagPipeline(application: Application) {
                         )
                     )
                     engine.initialize()
-                    Log.w("mam-ai", "[BACKEND] CPU fallback initialized successfully")
                 }
+                Log.w("mam-ai", "[BACKEND] *** LLM running on $activeBackend ***")
                 Log.w("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
                 val rt = Runtime.getRuntime()
                 Log.w("mam-ai", "[MEMORY] post-init heap: ${rt.totalMemory() / 1024 / 1024}MB used, ${rt.freeMemory() / 1024 / 1024}MB free, ${rt.maxMemory() / 1024 / 1024}MB max")

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -94,7 +94,7 @@ class RagPipeline(application: Application) {
     init {
         Executors.newSingleThreadExecutor().execute {
             try {
-                val useGpu = BuildConfig.USE_GPU_FOR_LLM || appConfig.optBoolean("use_gpu_for_llm", false)
+                val useGpu = BuildConfig.USE_GPU_FOR_LLM
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
                 try {

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -95,39 +95,30 @@ class RagPipeline(application: Application) {
         Executors.newSingleThreadExecutor().execute {
             try {
                 val useGpu = appConfig.optBoolean("use_gpu_for_llm", false)
-                Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
+                Log.i("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
                 try {
                     val backend = if (useGpu) {
-                        Log.w("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
+                        Log.i("mam-ai", "[BACKEND] Attempting GPU backend for LLM")
                         Backend.GPU()
                     } else {
-                        Log.w("mam-ai", "[BACKEND] Using CPU backend for LLM")
+                        Log.i("mam-ai", "[BACKEND] Using CPU backend for LLM")
                         Backend.CPU()
                     }
-                    engine = Engine(
-                        EngineConfig(
-                            modelPath = baseFolder + appConfig.getString("llm_model"),
-                            backend = backend,
-                            cacheDir = application.cacheDir.path,
-                        )
-                    )
-                    engine.initialize()
-                } catch (gpuError: Exception) {
+                    buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                } catch (gpuError: Throwable) {
                     if (!useGpu) throw gpuError
                     Log.w("mam-ai", "[BACKEND] WARNING: GPU init failed, falling back to CPU", gpuError)
                     activeBackend = "CPU"
-                    engine = Engine(
-                        EngineConfig(
-                            modelPath = baseFolder + appConfig.getString("llm_model"),
-                            backend = Backend.CPU(),
-                            cacheDir = application.cacheDir.path,
-                        )
-                    )
-                    engine.initialize()
+                    try {
+                        buildEngine(baseFolder + appConfig.getString("llm_model"), Backend.CPU(), application.cacheDir.path)
+                    } catch (cpuError: Throwable) {
+                        cpuError.addSuppressed(gpuError)
+                        throw cpuError
+                    }
                 }
                 Log.w("mam-ai", "[BACKEND] *** LLM running on $activeBackend ***")
-                Log.w("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
+                Log.i("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
                 val rt = Runtime.getRuntime()
                 Log.w("mam-ai", "[MEMORY] post-init heap: ${rt.totalMemory() / 1024 / 1024}MB used, ${rt.freeMemory() / 1024 / 1024}MB free, ${rt.maxMemory() / 1024 / 1024}MB max")
                 Log.i("mam-ai", "LLM initialized!")
@@ -316,6 +307,11 @@ class RagPipeline(application: Application) {
             Log.w("mam-ai", "[TIMING] total query: ${System.currentTimeMillis() - qStart}ms")
             result
         }
+
+    private fun buildEngine(modelPath: String, backend: Backend, cacheDir: String) {
+        engine = Engine(EngineConfig(modelPath = modelPath, backend = backend, cacheDir = cacheDir))
+        engine.initialize()
+    }
 
     companion object {
         private val CHUNK_SEPARATORS = listOf("<sep>", "<doc_sep>")

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -110,7 +110,17 @@ class RagPipeline(application: Application) {
                     Log.i("mam-ai", "[BACKEND] Using CPU backend for LLM")
                     Backend.CPU()
                 }
-                buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                if (useGpu && activeBackend == "GPU") {
+                    try {
+                        buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                    } catch (gpuInitError: Throwable) {
+                        Log.w("mam-ai", "[BACKEND] WARNING: GPU engine init failed, falling back to CPU", gpuInitError)
+                        activeBackend = "CPU"
+                        buildEngine(baseFolder + appConfig.getString("llm_model"), Backend.CPU(), application.cacheDir.path)
+                    }
+                } else {
+                    buildEngine(baseFolder + appConfig.getString("llm_model"), backend, application.cacheDir.path)
+                }
                 Log.w("mam-ai", "[BACKEND] *** LLM running on $activeBackend ***")
                 Log.i("mam-ai", "[TIMING] Engine ready: ${System.currentTimeMillis() - initStartTime}ms after construction")
                 val rt = Runtime.getRuntime()

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -4,5 +4,5 @@
   "tokenizer": "sentencepiece.model",
   "embedding_dim": 768,
   "use_gpu_for_embeddings": false,
-  "use_gpu_for_llm": true
+  "use_gpu_for_llm": false
 }

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -3,5 +3,6 @@
   "embedding_model": "Gecko_1024_quant.tflite",
   "tokenizer": "sentencepiece.model",
   "embedding_dim": 768,
-  "use_gpu_for_embeddings": false
+  "use_gpu_for_embeddings": false,
+  "use_gpu_for_llm": true
 }

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -3,6 +3,5 @@
   "embedding_model": "Gecko_1024_quant.tflite",
   "tokenizer": "sentencepiece.model",
   "embedding_dim": 768,
-  "use_gpu_for_embeddings": false,
-  "use_gpu_for_llm": false
+  "use_gpu_for_embeddings": false
 }


### PR DESCRIPTION
## Summary

- Bumps \`litertlm-android\` 0.10.0 → 0.10.2
- Adds GPU backend support to \`RagPipeline.kt\` with automatic CPU fallback if GPU init fails
- GPU flag controlled at compile time via Gradle property \`useGpuForLlm\` (default \`false\`); enable locally via \`~/.gradle/gradle.properties\`
- Adds \`uses-native-library\` entries for OpenCL in \`AndroidManifest.xml\`
- Logs \`[BACKEND] *** LLM running on GPU/CPU ***\` at startup for field diagnostics (addresses #51)

## Verified on device

Tested on OnePlus OPD2413 (Snapdragon 8 Elite, Adreno 830):
\`\`\`
[BACKEND] Attempting GPU backend for LLM
[BACKEND] *** LLM running on GPU ***
[TIMING] Engine ready: 10036ms after construction
\`\`\`
GPU backend confirmed working. Generation noticeably faster in practice.

## Follow-up

- #51 — identify Zanzibar target devices and check OpenCL support before wide rollout
- #52 — evaluate GPU backend for Gecko embeddings (intentionally left as CPU to isolate this change)

## Test plan

- [x] Build release APK and install on device
- [x] Confirm \`[BACKEND] *** LLM running on GPU ***\` in logcat
- [x] Submit a query and verify response generates correctly
- [ ] Confirm no crash on devices without OpenCL (fallback to CPU expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)