### PR TITLE
feat: bump litertlm-android to 0.11.0 and add MTP toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ Benchmarks run across AfriMedQA, MedQA USMLE, MedMCQA, Kenya Vignettes, AfriMedQ
 | Gemma 3n E4B (no-RAG) | 45.5% | 2.98 / 5 |
 | **Gemma 4 E4B (deployed, no-RAG)** | **42.9%** | **2.61 / 5** |
 
-RAG slightly hurts both on-device models on MCQ; GPT-5 is unaffected. GPU decode for Gemma 4 E4B is blocked pending a LiteRT-LM Android GPU release.
+RAG slightly hurts both on-device models on MCQ; GPT-5 is unaffected.
 
 On an OPPO Snapdragon 8 Elite device, Gemma 4 E4B averages **11.7 s TTFT**, **26.8 s total**, **13.8 tok/s** — slower TTFT than Gemma 3n E4B (6.8 s) despite faster decode.
+
+With LiteRT-LM 0.11.0 on GPU (opt-in), TTFT drops to ~1–2 s on the same device; decode rate is unchanged. Multi-token Prediction (`ExperimentalFlags.enableSpeculativeDecoding`, gated behind the `useMtpForLlm` Gradle property) was smoke-tested and produced a **~10–20% decode slowdown** rather than the vendor's claimed >2× — drafter acceptance is likely poor for our long retrieved-context prompts. Off by default; re-test before re-enabling.
 
 Full results: [eval report](evaluation/reports/eval_report_app_parity_v1.md) · [latency report](evaluation/reports/latency_report.md)
 

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -14,6 +14,10 @@ if (keystorePropertiesFile.exists()) {
 }
 
 val useGpuForLlm = project.findProperty("useGpuForLlm")?.toString()?.toBoolean() ?: false
+// Speculative decoding (MTP) — off by default. Smoke-tested 2026-05-14 on OPPO Snapdragon 8 Elite + GPU:
+// ~10–20% decode slowdown, 3/3 samples, vs. plain GPU. Drafter acceptance is likely poor for our
+// long retrieved-context prompts + constrained medical prose. Re-test before re-enabling.
+val useMtpForLlm = project.findProperty("useMtpForLlm")?.toString()?.toBoolean() ?: false
 
 fun propOrEnv(envName: String, propertyName: String): String? =
     System.getenv(envName)?.takeIf { it.isNotBlank() }
@@ -52,6 +56,7 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         buildConfigField("boolean", "USE_GPU_FOR_LLM", useGpuForLlm.toString())
+        buildConfigField("boolean", "USE_MTP_FOR_LLM", useMtpForLlm.toString())
     }
 
     sourceSets {
@@ -99,7 +104,7 @@ kotlin {
 }
 dependencies {
     implementation("com.google.ai.edge.localagents:localagents-rag:0.2.0")
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.10.2")
     implementation("com.google.protobuf:protobuf-javalite:3.25.4")
 }

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -16,6 +16,8 @@ import com.google.ai.edge.litertlm.Contents
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.ExperimentalApi
+import com.google.ai.edge.litertlm.ExperimentalFlags
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.SamplerConfig
 import kotlinx.coroutines.CompletableDeferred
@@ -36,6 +38,7 @@ data class RetrievedDoc(
 )
 
 /** The RAG pipeline for LLM generation. */
+@OptIn(ExperimentalApi::class)
 class RagPipeline(application: Application) {
     private val baseFolder = application.getExternalFilesDir(null).toString() + "/"
 
@@ -95,6 +98,13 @@ class RagPipeline(application: Application) {
         Executors.newSingleThreadExecutor().execute {
             try {
                 val useGpu = BuildConfig.USE_GPU_FOR_LLM
+                val useMtp = BuildConfig.USE_MTP_FOR_LLM
+                if (useMtp) {
+                    ExperimentalFlags.enableSpeculativeDecoding = true
+                    Log.w("mam-ai", "[MTP] speculative decoding ENABLED")
+                } else {
+                    Log.i("mam-ai", "[MTP] speculative decoding disabled")
+                }
                 Log.w("mam-ai", "[TIMING] Engine.initialize() starting...")
                 var activeBackend = if (useGpu) "GPU" else "CPU"
                 val modelPath = baseFolder + appConfig.getString("llm_model")


### PR DESCRIPTION
## Summary
- Bumps `com.google.ai.edge.litertlm:litertlm-android` from `0.10.2` → `0.11.0`.
- Adds a new Gradle property `useMtpForLlm` (default `false`) that opts the runtime into LiteRT-LM's Multi-token Prediction / speculative decoding (`ExperimentalFlags.enableSpeculativeDecoding`).
- Documents the smoke-test result for both changes in the README and inline near the new Gradle flag.

Supersedes #54 (same dependency bump, with extra wiring and the smoke-test write-up).

## Smoke-test results (OPPO Snapdragon 8 Elite, 2026-05-14)

LiteRT-LM 0.11.0 was tested locally with `useGpuForLlm=true`. Same model file (`gemma-4-E4B-it.litertlm`), same RAG bundle.

| Config | TTFT | Decode rate |
|---|---|---|
| 0.10.2 CPU (README baseline) | 11.7 s | 13.8 tok/s |
| **0.11.0 GPU, no MTP** | **~1–2 s** | ~12–14 tok/s |
| 0.11.0 GPU, MTP on | ~1–2 s | **~10–12 tok/s** (slower) |

- 0.11.0 on GPU gives a **~7× TTFT win** — the main payoff of this PR.
- MTP / speculative decoding was honoured at the native layer (`enable_speculative_decoding: true`, `tf_lite_mtp_drafter` subgraph loaded — confirmed in logcat) but produced a **~10–20% decode slowdown**, 3/3 samples. Most likely cause: low drafter acceptance rate on long retrieved-context prompts + constrained medical prose. Off by default; re-test before re-enabling.

## Risk notes
- API surface used in `RagPipeline.kt` (`Engine`, `EngineConfig`, `ConversationConfig`, `Backend`, `SamplerConfig`, `Message`, `Contents`) is source-compatible between 0.10.2 and 0.11.0 — verified via the v0.10.2…v0.11.0 commit log; the Kotlin API additions (`filterChannelContentFromKvCache`, file capability inspection, `prefer_activation_type`) are all additive.
- Per `CLAUDE.md`'s eval-gated deployment rule, this is a smoke test, not a full eval. Full clinical eval still pending before any decision to flip GPU on by default in production.

## Test plan
- [ ] Build APK (CPU default): `flutter build apk` — verify `[BACKEND] *** LLM running on CPU ***` in logcat.
- [ ] Build APK (GPU): `flutter build apk -PuseGpuForLlm=true` — verify `[BACKEND] *** LLM running on GPU ***`.
- [ ] Build APK (GPU + MTP): `flutter build apk -PuseGpuForLlm=true -PuseMtpForLlm=true` — verify `[MTP] speculative decoding ENABLED` and `tf_lite_mtp_drafter` lines in logcat.
- [ ] Run a slice of `kenya_vignettes` through the eval harness against 0.11.0 before considering for production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)