### PR TITLE
feat(about): fall back to pinned bundle info; show runtime versions

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -19,6 +19,10 @@ val useGpuForLlm = project.findProperty("useGpuForLlm")?.toString()?.toBoolean()
 // long retrieved-context prompts + constrained medical prose. Re-test before re-enabling.
 val useMtpForLlm = project.findProperty("useMtpForLlm")?.toString()?.toBoolean() ?: false
 
+// Used in both the dependency declaration below and the BuildConfig field so the About page
+// can surface what's actually linked at build time. Update in lockstep with the dependency.
+val litertlmVersion = "0.11.0"
+
 fun propOrEnv(envName: String, propertyName: String): String? =
     System.getenv(envName)?.takeIf { it.isNotBlank() }
         ?: (keystoreProperties.getProperty(propertyName)?.takeIf { it.isNotBlank() })
@@ -57,6 +61,7 @@ android {
         versionName = flutter.versionName
         buildConfigField("boolean", "USE_GPU_FOR_LLM", useGpuForLlm.toString())
         buildConfigField("boolean", "USE_MTP_FOR_LLM", useMtpForLlm.toString())
+        buildConfigField("String", "LITERTLM_VERSION", "\"$litertlmVersion\"")
     }
 
     sourceSets {
@@ -104,7 +109,7 @@ kotlin {
 }
 dependencies {
     implementation("com.google.ai.edge.localagents:localagents-rag:0.2.0")
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.11.0")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:$litertlmVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.10.2")
     implementation("com.google.protobuf:protobuf-javalite:3.25.4")
 }

--- a/app/android/app/src/main/kotlin/com/example/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/MainActivity.kt
@@ -74,6 +74,9 @@ class MainActivity : FlutterActivity() {
                 "getPinnedRagBundleInfo" -> {
                     result.success(getPinnedRagBundleInfo())
                 }
+                "getRuntimeInfo" -> {
+                    result.success(getRuntimeInfo())
+                }
                 "startDownloadService" -> {
                     // Start the ForegroundService so the OS keeps the process alive
                     // while downloads run in the background.  We do NOT request
@@ -183,6 +186,14 @@ class MainActivity : FlutterActivity() {
             Log.w("mam-ai", "[RAG] failed to read pinned bundle metadata", e)
             null
         }
+
+    private fun getRuntimeInfo(): Map<String, Any> = mapOf(
+        "appVersionName" to BuildConfig.VERSION_NAME,
+        "appVersionCode" to BuildConfig.VERSION_CODE,
+        "litertlmVersion" to BuildConfig.LITERTLM_VERSION,
+        "llmBackendConfigured" to if (BuildConfig.USE_GPU_FOR_LLM) "GPU" else "CPU",
+        "mtpEnabled" to BuildConfig.USE_MTP_FOR_LLM,
+    )
 
     private fun openPdf(source: String, page: Int): Boolean {
         val baseFolder = application.getExternalFilesDir(null) ?: return false

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -46,6 +46,11 @@
   "aboutKnowledgeBundleUnavailable": "Bundle metadata is not available on this device yet.",
   "aboutKnowledgeBundleVersionLabel": "Version",
   "aboutKnowledgeBundleDeployedLabel": "Deployed",
+  "aboutKnowledgeBundlePinnedNote": "Pinned in this build; deployment receipt not found on device.",
+  "aboutRuntimeTitle": "Runtime",
+  "aboutRuntimeAppLabel": "App",
+  "aboutRuntimeLitertlmLabel": "LiteRT-LM",
+  "aboutRuntimeBackendLabel": "LLM backend",
 
   "drawerAbout": "About MAM-AI",
   "drawerTitle": "Past conversations",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -290,6 +290,36 @@ abstract class AppLocalizations {
   /// **'Deployed'**
   String get aboutKnowledgeBundleDeployedLabel;
 
+  /// No description provided for @aboutKnowledgeBundlePinnedNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Pinned in this build; deployment receipt not found on device.'**
+  String get aboutKnowledgeBundlePinnedNote;
+
+  /// No description provided for @aboutRuntimeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Runtime'**
+  String get aboutRuntimeTitle;
+
+  /// No description provided for @aboutRuntimeAppLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'App'**
+  String get aboutRuntimeAppLabel;
+
+  /// No description provided for @aboutRuntimeLitertlmLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'LiteRT-LM'**
+  String get aboutRuntimeLitertlmLabel;
+
+  /// No description provided for @aboutRuntimeBackendLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'LLM backend'**
+  String get aboutRuntimeBackendLabel;
+
   /// No description provided for @drawerAbout.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -116,6 +116,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aboutKnowledgeBundleDeployedLabel => 'Deployed';
 
   @override
+  String get aboutKnowledgeBundlePinnedNote =>
+      'Pinned in this build; deployment receipt not found on device.';
+
+  @override
+  String get aboutRuntimeTitle => 'Runtime';
+
+  @override
+  String get aboutRuntimeAppLabel => 'App';
+
+  @override
+  String get aboutRuntimeLitertlmLabel => 'LiteRT-LM';
+
+  @override
+  String get aboutRuntimeBackendLabel => 'LLM backend';
+
+  @override
   String get drawerAbout => 'About MAM-AI';
 
   @override

--- a/app/lib/l10n/app_localizations_sw.dart
+++ b/app/lib/l10n/app_localizations_sw.dart
@@ -115,6 +115,22 @@ class AppLocalizationsSw extends AppLocalizations {
   String get aboutKnowledgeBundleDeployedLabel => 'Kimepelekwa';
 
   @override
+  String get aboutKnowledgeBundlePinnedNote =>
+      'Pinned in this build; deployment receipt not found on device.';
+
+  @override
+  String get aboutRuntimeTitle => 'Runtime';
+
+  @override
+  String get aboutRuntimeAppLabel => 'App';
+
+  @override
+  String get aboutRuntimeLitertlmLabel => 'LiteRT-LM';
+
+  @override
+  String get aboutRuntimeBackendLabel => 'LLM backend';
+
+  @override
   String get drawerAbout => 'Kuhusu MAM-AI';
 
   @override

--- a/app/lib/l10n/app_sw.arb
+++ b/app/lib/l10n/app_sw.arb
@@ -46,6 +46,11 @@
   "aboutKnowledgeBundleUnavailable": "Taarifa za kifurushi bado hazipatikani kwenye kifaa hiki.",
   "aboutKnowledgeBundleVersionLabel": "Toleo",
   "aboutKnowledgeBundleDeployedLabel": "Kimepelekwa",
+  "aboutKnowledgeBundlePinnedNote": "Pinned in this build; deployment receipt not found on device.",
+  "aboutRuntimeTitle": "Runtime",
+  "aboutRuntimeAppLabel": "App",
+  "aboutRuntimeLitertlmLabel": "LiteRT-LM",
+  "aboutRuntimeBackendLabel": "LLM backend",
 
   "drawerAbout": "Kuhusu MAM-AI",
   "drawerTitle": "Mazungumzo ya zamani",

--- a/app/lib/screens/about_page.dart
+++ b/app/lib/screens/about_page.dart
@@ -15,20 +15,36 @@ class _AboutPageState extends State<AboutPage> {
   );
 
   late final Future<RagBundleInfo?> _bundleInfoFuture;
+  late final Future<RuntimeInfo?> _runtimeInfoFuture;
 
   @override
   void initState() {
     super.initState();
     _bundleInfoFuture = _loadBundleInfo();
+    _runtimeInfoFuture = _loadRuntimeInfo();
   }
 
   Future<RagBundleInfo?> _loadBundleInfo() async {
+    final deployed = await _invokeMap("getDeployedRagBundleInfo");
+    if (deployed != null) {
+      return RagBundleInfo.fromMap(deployed, source: BundleInfoSource.deployed);
+    }
+    final pinned = await _invokeMap("getPinnedRagBundleInfo");
+    if (pinned != null) {
+      return RagBundleInfo.fromMap(pinned, source: BundleInfoSource.pinned);
+    }
+    return null;
+  }
+
+  Future<RuntimeInfo?> _loadRuntimeInfo() async {
+    final raw = await _invokeMap("getRuntimeInfo");
+    if (raw == null) return null;
+    return RuntimeInfo.fromMap(raw);
+  }
+
+  Future<Map<String, dynamic>?> _invokeMap(String method) async {
     try {
-      final raw = await _platform.invokeMapMethod<String, dynamic>(
-        "getDeployedRagBundleInfo",
-      );
-      if (raw == null) return null;
-      return RagBundleInfo.fromMap(raw);
+      return await _platform.invokeMapMethod<String, dynamic>(method);
     } on PlatformException {
       return null;
     } on MissingPluginException {
@@ -78,6 +94,8 @@ class _AboutPageState extends State<AboutPage> {
             ),
             const SizedBox(height: 36),
             _BundleInfoCard(bundleInfoFuture: _bundleInfoFuture),
+            const SizedBox(height: 16),
+            _RuntimeInfoCard(runtimeInfoFuture: _runtimeInfoFuture),
             const SizedBox(height: 36),
 
             // Partnership
@@ -110,19 +128,51 @@ class _AboutPageState extends State<AboutPage> {
   }
 }
 
+enum BundleInfoSource { deployed, pinned }
+
 class RagBundleInfo {
   final String bundleVersion;
   final String deployedAtUtc;
+  final BundleInfoSource source;
 
   const RagBundleInfo({
     required this.bundleVersion,
     required this.deployedAtUtc,
+    required this.source,
   });
 
-  factory RagBundleInfo.fromMap(Map<String, dynamic> raw) {
+  factory RagBundleInfo.fromMap(
+    Map<String, dynamic> raw, {
+    required BundleInfoSource source,
+  }) {
     return RagBundleInfo(
       bundleVersion: raw['bundleVersion']?.toString() ?? '',
       deployedAtUtc: raw['deployedAtUtc']?.toString() ?? '',
+      source: source,
+    );
+  }
+}
+
+class RuntimeInfo {
+  final String appVersion;
+  final String litertlmVersion;
+  final String llmBackend;
+
+  const RuntimeInfo({
+    required this.appVersion,
+    required this.litertlmVersion,
+    required this.llmBackend,
+  });
+
+  factory RuntimeInfo.fromMap(Map<String, dynamic> raw) {
+    final name = raw['appVersionName']?.toString() ?? '';
+    final code = raw['appVersionCode']?.toString() ?? '';
+    final appVersion =
+        code.isNotEmpty && name.isNotEmpty ? '$name ($code)' : name;
+    return RuntimeInfo(
+      appVersion: appVersion,
+      litertlmVersion: raw['litertlmVersion']?.toString() ?? '',
+      llmBackend: raw['llmBackendConfigured']?.toString() ?? '',
     );
   }
 }
@@ -206,6 +256,82 @@ class _BundleInfoCard extends StatelessWidget {
                   value: info.deployedAtUtc,
                 ),
               ],
+              if (info.source == BundleInfoSource.pinned) ...[
+                const SizedBox(height: 10),
+                Text(
+                  l10n.aboutKnowledgeBundlePinnedNote,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontStyle: FontStyle.italic,
+                    color: Color(0xff786A5E),
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RuntimeInfoCard extends StatelessWidget {
+  final Future<RuntimeInfo?> runtimeInfoFuture;
+
+  const _RuntimeInfoCard({required this.runtimeInfoFuture});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xffF8F5F1),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xffE7DED3)),
+      ),
+      child: FutureBuilder<RuntimeInfo?>(
+        future: runtimeInfoFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(strokeWidth: 2.4),
+              ),
+            );
+          }
+          final info = snapshot.data;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.aboutRuntimeTitle,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xff4E4338),
+                ),
+              ),
+              const SizedBox(height: 14),
+              _BundleInfoRow(
+                label: l10n.aboutRuntimeAppLabel,
+                value: info?.appVersion ?? '—',
+              ),
+              const SizedBox(height: 10),
+              _BundleInfoRow(
+                label: l10n.aboutRuntimeLitertlmLabel,
+                value: info?.litertlmVersion ?? '—',
+              ),
+              const SizedBox(height: 10),
+              _BundleInfoRow(
+                label: l10n.aboutRuntimeBackendLabel,
+                value: info?.llmBackend ?? '—',
+              ),
             ],
           );
         },


### PR DESCRIPTION
## Summary
About page used to silently show "Bundle metadata is not available on this device yet" whenever the deployment receipt (`rag_bundle_deployed.json`) was missing — even when the bundle is healthy and retrieval works. This commonly affects tablets provisioned before the receipt-writing code was added to the in-app downloader.

This PR makes the page useful even in that state, and surfaces the runtime versions someone debugging on-device behaviour usually needs.

## Changes

### Bundle card
- Try `getDeployedRagBundleInfo` first; on null, fall back to `getPinnedRagBundleInfo` (reads `rag_assets.lock.json` from the APK's assets).
- Fallback rendering tags itself with an italic note (*"Pinned in this build; deployment receipt not found on device."*) — explicit so we don't claim the bundle is verifiably deployed when we only have build-time info.

### New Runtime card
- App version (`versionName (versionCode)`)
- LiteRT-LM version (new `BuildConfig.LITERTLM_VERSION`, kept in sync with the Gradle dependency via a single `litertlmVersion` constant)
- Configured LLM backend (`GPU`/`CPU` per `BuildConfig.USE_GPU_FOR_LLM`)
- Wired through a new `getRuntimeInfo` MethodChannel handler in `MainActivity.kt`.

### Backend wiring
- `MainActivity.kt` — new `getRuntimeInfo` case + private method.
- `build.gradle.kts` — single `litertlmVersion = "0.11.0"` constant used both in the dependency declaration and as `BuildConfig.LITERTLM_VERSION`.

### Localization
- New keys in both `app_en.arb` and `app_sw.arb`:
  - `aboutKnowledgeBundlePinnedNote`
  - `aboutRuntimeTitle`
  - `aboutRuntimeAppLabel`
  - `aboutRuntimeLitertlmLabel`
  - `aboutRuntimeBackendLabel`
- ⚠️ **Swahili strings are English placeholders** — need translation in a follow-up; flagged here so reviewers don't miss it.

## Tested on device
- OPPO Snapdragon 8 Elite, with no `rag_bundle_deployed.json` on disk.
- About page renders bundle version from the pinned source with the italic note.
- Runtime card shows `App: 0.1.0 (1)`, `LiteRT-LM: 0.11.0`, `LLM backend: GPU`.
- Retrieval + generation continue to work normally during/after viewing the page.

## Test plan
- [ ] Build APK and install on a tablet that **does** have a `rag_bundle_deployed.json` — verify the bundle card shows `Deployed: <timestamp>` and *no* italic pinned-note appears (deployed path is preferred).
- [ ] Build APK and install on a tablet **without** a receipt — verify the italic note is shown.
- [ ] Verify Swahili locale shows the new fields (currently English text) and decide whether to follow up with proper translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)