### PR TITLE
feat(benchmark): generalize on-device eval branch for open-ended + RAG

### DIFF
--- a/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
@@ -473,8 +473,8 @@ class BenchmarkForegroundService : Service() {
      * On-device evaluation runner. Reads a pushed `eval_input.json`
      * ({system_prompt, use_retrieval?, rows: [{id, user_message, history?}]}),
      * iterates rows through the same LiteRT pipeline production uses, and
-     * writes `eval_output.json` ({rows: [{id, response_text, error?}]}) for
-     * the harness (run_eval_device.py) to pull and score.
+     * writes `eval_output.json` ({rows: [{id, response_text, inference_time_ms,
+     * error}]}) for the harness (run_eval_device.py) to pull and score.
      *
      * Tracks:
      *  - MCQ / SAQ no-RAG: `use_retrieval=false` → the pre-built `user_message`
@@ -537,8 +537,9 @@ class BenchmarkForegroundService : Service() {
             // Optional multi-turn history (healthbench): [{role, text}, …] replayed
             // before user_message. Absent for single-turn MCQ/SAQ rows.
             // RagPipeline maps role=="user" → user turn and everything else →
-            // model turn, so normalize to "user"/"model" here and fail loudly on
-            // anything unexpected rather than silently mis-attributing a turn.
+            // model turn, so normalize to "user"/"model" here; skip blank turns,
+            // and log + skip an unrecognized role rather than silently
+            // mis-attributing it as a model turn.
             val history = mutableListOf<Map<String, String>>()
             row.optJSONArray("history")?.let { h ->
                 for (j in 0 until h.length()) {

--- a/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
@@ -536,14 +536,25 @@ class BenchmarkForegroundService : Service() {
             val userMessage = row.getString("user_message")
             // Optional multi-turn history (healthbench): [{role, text}, …] replayed
             // before user_message. Absent for single-turn MCQ/SAQ rows.
+            // RagPipeline maps role=="user" → user turn and everything else →
+            // model turn, so normalize to "user"/"model" here and fail loudly on
+            // anything unexpected rather than silently mis-attributing a turn.
             val history = mutableListOf<Map<String, String>>()
             row.optJSONArray("history")?.let { h ->
                 for (j in 0 until h.length()) {
                     val turn = h.getJSONObject(j)
-                    history.add(mapOf(
-                        "role" to turn.optString("role", "user"),
-                        "text" to turn.optString("text", ""),
-                    ))
+                    val text = turn.optString("text", "").trim()
+                    if (text.isEmpty()) continue  // skip blank turns
+                    val role = when (turn.optString("role", "").trim().lowercase()) {
+                        "user", "human" -> "user"
+                        "assistant", "model", "bot", "ai" -> "model"
+                        else -> {
+                            Log.e(BENCH_TAG, "[BENCHMARK] row $id history turn $j has " +
+                                "unrecognized role='${turn.optString("role")}'; skipping turn")
+                            continue
+                        }
+                    }
+                    history.add(mapOf("role" to role, "text" to text))
                 }
             }
             updateNotification("[${i + 1}/${rows.length()}] $id", i + 1, rows.length())

--- a/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/BenchmarkForegroundService.kt
@@ -150,7 +150,7 @@ class BenchmarkForegroundService : Service() {
         scope.launch {
             try {
                 if (evalMode) {
-                    runMcqEval()
+                    runEval()
                 } else {
                     runBenchmark(repeats, cooldownMs, skipRetrieval, ragOnly, queryFilter, retrieveKOverride)
                 }
@@ -467,22 +467,28 @@ class BenchmarkForegroundService : Service() {
         Log.w(BENCH_TAG, "[BENCHMARK] COMPLETE")
     }
 
-    // ── MCQ eval mode ────────────────────────────────────────────────────
+    // ── Eval mode (MCQ + open-ended SAQ/rubric) ──────────────────────────
 
     /**
-     * On-device MCQ evaluation runner. Reads a pushed
-     * `eval_input.json` ({system_prompt, rows: [{id, user_message}]}),
-     * iterates rows through the same LiteRT pipeline production uses,
-     * but with the MCQ adapter system prompt and no retrieval. Writes
-     * `eval_output.json` ({rows: [{id, response_text, error?}]}) for
+     * On-device evaluation runner. Reads a pushed `eval_input.json`
+     * ({system_prompt, use_retrieval?, rows: [{id, user_message, history?}]}),
+     * iterates rows through the same LiteRT pipeline production uses, and
+     * writes `eval_output.json` ({rows: [{id, response_text, error?}]}) for
      * the harness (run_eval_device.py) to pull and score.
      *
-     * Triggered via `am start ... --ez eval_mode true`. Production paths
-     * are unreachable from this branch — production chat continues to
-     * use the deployed system prompt and the default RAG-injection
-     * behaviour.
+     * Tracks:
+     *  - MCQ / SAQ no-RAG: `use_retrieval=false` → the pre-built `user_message`
+     *    is sent verbatim (bypassPromptFormatting) with no retrieval.
+     *  - SAQ / rubric +RAG: `use_retrieval=true` → on-device retrieval runs and
+     *    the deployed context-injection formatting is applied (production path),
+     *    so the eval exercises the real retrieval + injection stack.
+     *  - Multi-turn (healthbench): optional per-row `history`
+     *    ([{role: "user"|"model", text}]) is replayed as conversation history.
+     *
+     * Triggered via `am start ... --ez eval_mode true`. Production chat paths
+     * are unreachable from this branch.
      */
-    private suspend fun runMcqEval() {
+    private suspend fun runEval() {
         val timestamp = SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.US).format(Date())
         val evalStart = System.currentTimeMillis()
         Log.w(BENCH_TAG, "[BENCHMARK] START eval_mode=true")
@@ -501,7 +507,11 @@ class BenchmarkForegroundService : Service() {
             return
         }
         val rows = input.getJSONArray("rows")
-        Log.w(BENCH_TAG, "[BENCHMARK] eval rows: ${rows.length()}, system_prompt: ${systemPrompt.length} chars")
+        // When true, run on-device retrieval + the deployed context-injection
+        // formatting (production path). When false (MCQ / SAQ no-RAG), send the
+        // pre-built user_message verbatim with no retrieval.
+        val useRetrieval = input.optBoolean("use_retrieval", false)
+        Log.w(BENCH_TAG, "[BENCHMARK] eval rows: ${rows.length()}, system_prompt: ${systemPrompt.length} chars, use_retrieval=$useRetrieval")
 
         updateNotification("Initializing pipeline (eval mode)…", -1, 0)
         Log.w(BENCH_TAG, "[BENCHMARK] Initializing pipeline (Gecko + SQLite)...")
@@ -524,6 +534,18 @@ class BenchmarkForegroundService : Service() {
             val row = rows.getJSONObject(i)
             val id = row.getString("id")
             val userMessage = row.getString("user_message")
+            // Optional multi-turn history (healthbench): [{role, text}, …] replayed
+            // before user_message. Absent for single-turn MCQ/SAQ rows.
+            val history = mutableListOf<Map<String, String>>()
+            row.optJSONArray("history")?.let { h ->
+                for (j in 0 until h.length()) {
+                    val turn = h.getJSONObject(j)
+                    history.add(mapOf(
+                        "role" to turn.optString("role", "user"),
+                        "text" to turn.optString("text", ""),
+                    ))
+                }
+            }
             updateNotification("[${i + 1}/${rows.length()}] $id", i + 1, rows.length())
             Log.w(BENCH_TAG, "[BENCHMARK] eval ${i + 1}/${rows.length()} id=$id")
 
@@ -534,12 +556,14 @@ class BenchmarkForegroundService : Service() {
                 withContext(executor.asCoroutineDispatcher()) {
                     pipeline.generateResponse(
                         prompt = userMessage,
-                        history = emptyList(),
-                        useRetrieval = false,
+                        history = history,
+                        useRetrieval = useRetrieval,
                         retrievalListener = {},
                         generationListener = { partial, _ -> response.append(partial) },
                         systemInstructionsOverride = systemPrompt,
-                        bypassPromptFormatting = true,
+                        // Verbatim only on the no-retrieval path (caller pre-built the
+                        // message). With retrieval, use the deployed injection formatting.
+                        bypassPromptFormatting = !useRetrieval,
                     )
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
## What

Generalizes the Android `BenchmarkForegroundService` eval branch so the on-device harness can drive **open-ended** evals (SAQ + HealthBench rubric) and **on-device RAG**, not just MCQ.

## Changes
- `runMcqEval` → `runEval` — handles any eval set type, not only multiple-choice.
- Reads `use_retrieval` from the eval input (`bypassPromptFormatting = !useRetrieval`), so a single arm can run with or without on-device retrieval (Gecko + vector store).
- Per-row `history` array → conversation history, for HealthBench-style multi-turn rows.

Build-validated via a rebuilt APK and exercised end-to-end by the eval-side harness.

## Why

This is the app-side half of the device-fidelity work. The eval harness (`run_eval_device.py` in **nmrenyi/mamai-eval#6**) pushes an `eval_input.json`, triggers this service in eval mode, and pulls `eval_output.json`. We used it to confirm the cluster host proxy is a faithful (slightly pessimistic) stand-in for the deployed LiteRT device across SAQ and HealthBench, ±RAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
