### PR TITLE
Swap retriever to on-device EmbeddingGemma-300M (v0.3.0 bundle)

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -132,6 +132,10 @@ dependencies {
     implementation("com.google.ai.edge.litertlm:litertlm-android:$litertlmVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.10.2")
     implementation("com.google.protobuf:protobuf-javalite:3.25.4")
+    // LiteRT runtime — provides org.tensorflow.lite.Interpreter used by
+    // EmbeddingGemmaEmbedder to run the EmbeddingGemma .tflite on CPU/XNNPACK.
+    // (Already present transitively via the RAG/LLM stack; pinned explicitly.)
+    implementation("com.google.ai.edge.litert:litert:1.0.1")
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}

--- a/app/android/app/src/main/kotlin/com/example/app/EmbeddingGemmaEmbedder.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/EmbeddingGemmaEmbedder.kt
@@ -1,0 +1,91 @@
+package com.example.app
+
+import com.google.ai.edge.localagents.rag.models.EmbedData
+import com.google.ai.edge.localagents.rag.models.Embedder
+import com.google.ai.edge.localagents.rag.models.EmbeddingRequest
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import org.tensorflow.lite.Interpreter
+import java.io.File
+import kotlin.math.sqrt
+
+/**
+ * On-device EmbeddingGemma-300M retriever embedder, implementing the localagents
+ * RAG [Embedder] contract so it is a drop-in replacement for [com.google.ai.edge.localagents.rag.models.GeckoEmbeddingModel].
+ *
+ * Runs the `embeddinggemma-300M_seq256_mixed-precision.tflite` int4/int8 export via
+ * the TFLite/LiteRT [Interpreter] (CPU/XNNPACK — the GPU delegate fails op support
+ * for this model). Tokenisation uses [SentencePieceBpe] with the Gemma SentencePiece
+ * model and EmbeddingGemma's task prompts.
+ *
+ * Encoding (validated byte-for-byte against the PyTorch `sentence-transformers`
+ * reference): `[BOS] + spm(prompt + text) + [EOS]`, truncate/right-pad to 256
+ * int32 token ids; output is the 768-dim pooled embedding, L2-normalised. Query vs
+ * document prompt is selected from the [EmbedData.TaskType]; the app only embeds
+ * queries on-device (documents are pre-embedded in the shipped vector store).
+ *
+ * The TFLite interpreter is not thread-safe; all inference is serialised on [lock].
+ * Queries are already single-flighted upstream (RagStream), so this is uncontended.
+ */
+class EmbeddingGemmaEmbedder(
+    modelPath: String,
+    tokenizerPath: String,
+    private val seqLen: Int = 256,
+    numThreads: Int = 4,
+) : Embedder<String> {
+
+    private val tokenizer = SentencePieceBpe.load(tokenizerPath)
+    private val interpreter: Interpreter =
+        Interpreter(File(modelPath), Interpreter.Options().apply { setNumThreads(numThreads) })
+    private val lock = Any()
+
+    private fun promptFor(task: EmbedData.TaskType?): String =
+        if (task == EmbedData.TaskType.RETRIEVAL_DOCUMENT) DOC_PROMPT else QUERY_PROMPT
+
+    private fun embedOne(text: String, task: EmbedData.TaskType?): ImmutableList<Float> {
+        // [BOS] + spm(prompt + text) + [EOS], truncate/pad to seqLen.
+        val pieces = tokenizer.encodeAsIds(promptFor(task) + text)
+        val input = Array(1) { IntArray(seqLen) }
+        var n = 0
+        if (n < seqLen) input[0][n++] = SentencePieceBpe.BOS
+        var i = 0
+        while (i < pieces.size && n < seqLen - 1) { input[0][n++] = pieces[i]; i++ }
+        if (n < seqLen) input[0][n++] = SentencePieceBpe.EOS
+        // remaining entries stay 0 (pad id)
+
+        val output = Array(1) { FloatArray(EMBED_DIM) }
+        synchronized(lock) { interpreter.run(input, output) }
+
+        val v = output[0]
+        var norm = 0f
+        for (x in v) norm += x * x
+        norm = sqrt(norm) + 1e-9f
+        val b = ImmutableList.builder<Float>()
+        for (x in v) b.add(x / norm)
+        return b.build()
+    }
+
+    override fun getEmbeddings(
+        request: EmbeddingRequest<String>
+    ): ListenableFuture<ImmutableList<Float>> {
+        val d = request.embedData[0]
+        return Futures.immediateFuture(embedOne(d.data, d.task))
+    }
+
+    override fun getBatchEmbeddings(
+        request: EmbeddingRequest<String>
+    ): ListenableFuture<ImmutableList<ImmutableList<Float>>> {
+        val b = ImmutableList.builder<ImmutableList<Float>>()
+        for (d in request.embedData) b.add(embedOne(d.data, d.task))
+        return Futures.immediateFuture(b.build())
+    }
+
+    companion object {
+        private const val EMBED_DIM = 768
+        // EmbeddingGemma's built-in task prompts (exact; must match the prompts
+        // used to embed the corpus in the producer pipeline).
+        private const val QUERY_PROMPT = "task: search result | query: "
+        private const val DOC_PROMPT = "title: none | text: "
+    }
+}

--- a/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/RagPipeline.kt
@@ -69,12 +69,25 @@ class RagPipeline(application: Application) {
         Log.w("mam-ai", "[TIMING] Thread: ${Thread.currentThread().name} — starting heavy init")
 
         val t1 = System.currentTimeMillis()
-        embedder = GeckoEmbeddingModel(
-            baseFolder + appConfig.getString("embedding_model"),
-            Optional.of(baseFolder + appConfig.getString("tokenizer")),
-            appConfig.getBoolean("use_gpu_for_embeddings"),
-        )
-        Log.w("mam-ai", "[TIMING] GeckoEmbeddingModel constructor: ${System.currentTimeMillis() - t1}ms")
+        // Embedder is config-selectable: "gecko" (legacy Gecko TFLite, native) or
+        // "embeddinggemma" (EmbeddingGemma-300M int4/int8 TFLite via our custom
+        // Embedder). The vector store MUST have been built with the matching
+        // embedder — they live in different vector spaces.
+        val embedderType = appConfig.optString("embedder", "gecko")
+        embedder = if (embedderType == "embeddinggemma") {
+            EmbeddingGemmaEmbedder(
+                baseFolder + appConfig.getString("embedding_model"),
+                baseFolder + appConfig.getString("tokenizer"),
+                appConfig.optInt("embedding_seq_len", 256),
+            )
+        } else {
+            GeckoEmbeddingModel(
+                baseFolder + appConfig.getString("embedding_model"),
+                Optional.of(baseFolder + appConfig.getString("tokenizer")),
+                appConfig.getBoolean("use_gpu_for_embeddings"),
+            )
+        }
+        Log.w("mam-ai", "[TIMING] embedder ($embedderType) constructor: ${System.currentTimeMillis() - t1}ms")
 
         val t2 = System.currentTimeMillis()
         textMemory = DefaultSemanticTextMemory(

--- a/app/android/app/src/main/kotlin/com/example/app/SentencePieceBpe.kt
+++ b/app/android/app/src/main/kotlin/com/example/app/SentencePieceBpe.kt
@@ -1,0 +1,175 @@
+/**
+ * Minimal SentencePiece BPE tokenizer for EmbeddingGemma's Gemma tokenizer.
+ * Pure-JVM (no Android deps) so it can be unit-validated with kotlinc against the
+ * Python `sentencepiece` reference, then dropped into the Android app verbatim.
+ *
+ * Model facts (verified from sentencepiece.model): model_type=BPE,
+ * byte_fallback=true, add_dummy_prefix=false, escape_whitespaces=true
+ * (space -> U+2581 '▁'), normalization=identity. Byte tokens "<0xNN>" present.
+ */
+package com.example.app
+
+import java.io.File
+
+class SentencePieceBpe private constructor(
+    private val pieceToId: HashMap<String, Int>,
+    private val idScore: FloatArray,
+    private val byteTokenId: IntArray,   // 0..255 -> id of "<0xNN>"
+    private val userDefined: List<String>,
+    val unkId: Int,
+) {
+    private val space = "▁" // ▁
+
+    /** Encode raw text to token ids (BPE), no special tokens added. */
+    fun encodeAsIds(text: String): IntArray {
+        // escape_whitespaces: replace ' ' with ▁ (no dummy prefix).
+        val norm = text.replace(" ", space)
+        // 1) split into symbols (longest user-defined match, else one codepoint)
+        val symbols = ArrayList<String>()
+        var i = 0
+        while (i < norm.length) {
+            val ud = matchUserDefined(norm, i)
+            if (ud != null) { symbols.add(ud); i += ud.length }
+            else { val cp = norm.codePointAt(i); val s = String(Character.toChars(cp)); symbols.add(s); i += s.length }
+        }
+        if (symbols.isEmpty()) return IntArray(0)
+
+        // 2) BPE merge using a doubly-linked list + priority queue keyed by
+        //    (merged-piece score desc, left index asc) — matches SP bpe_model.cc.
+        val syms = symbols.toMutableList()
+        val prev = IntArray(syms.size) { it - 1 }
+        val next = IntArray(syms.size) { if (it == syms.size - 1) -1 else it + 1 }
+        val alive = BooleanArray(syms.size) { true }
+
+        data class Pair3(val left: Int, val right: Int, val score: Float, val merged: String)
+        val pq = java.util.PriorityQueue<Pair3>(compareByDescending<Pair3> { it.score }.thenBy { it.left })
+        fun tryAdd(l: Int, r: Int) {
+            if (l < 0 || r < 0) return
+            val m = syms[l] + syms[r]
+            val id = pieceToId[m] ?: return
+            pq.add(Pair3(l, r, idScore[id], m))
+        }
+        for (k in 0 until syms.size - 1) tryAdd(k, k + 1)
+
+        while (pq.isNotEmpty()) {
+            val p = pq.poll()
+            if (!alive[p.left] || !alive[p.right]) continue
+            if (next[p.left] != p.right) continue
+            if (syms[p.left] + syms[p.right] != p.merged) continue
+            // merge right into left
+            syms[p.left] = p.merged
+            alive[p.right] = false
+            val nr = next[p.right]
+            next[p.left] = nr
+            if (nr >= 0) prev[nr] = p.left
+            tryAdd(prev[p.left], p.left)
+            tryAdd(p.left, next[p.left])
+        }
+
+        // 3) emit ids; byte-fallback for symbols not in vocab
+        val out = ArrayList<Int>()
+        var idx = 0
+        // find head
+        var head = 0; while (head < alive.size && !alive[head]) head++
+        var c = head
+        // walk via next[] from the first alive symbol that is index 0's chain head
+        // (index 0 is always alive: merges only kill right elements)
+        c = 0
+        while (c != -1) {
+            val s = syms[c]
+            val id = pieceToId[s]
+            if (id != null) out.add(id)
+            else for (b in s.toByteArray(Charsets.UTF_8)) out.add(byteTokenId[b.toInt() and 0xFF])
+            c = next[c]
+        }
+        idx++
+        return out.toIntArray()
+    }
+
+    private fun matchUserDefined(s: String, pos: Int): String? {
+        var best: String? = null
+        for (u in userDefined) {
+            if (u.length > best?.length ?: 0 && s.regionMatches(pos, u, 0, u.length)) best = u
+        }
+        return best
+    }
+
+    companion object {
+        const val BOS = 2
+        const val EOS = 1
+
+        fun load(modelPath: String): SentencePieceBpe = loadBytes(File(modelPath).readBytes())
+
+        fun loadBytes(buf: ByteArray): SentencePieceBpe {
+            val pieceToId = HashMap<String, Int>(300000)
+            val scores = ArrayList<Float>(262144)
+            val byteTokenId = IntArray(256) { -1 }
+            val userDefined = ArrayList<String>()
+            var unkId = 3
+            var id = 0
+            var p = 0
+            // top-level ModelProto: field 1 (pieces) = length-delimited submessages
+            while (p < buf.size) {
+                val (tag, p1) = readVarint(buf, p); p = p1
+                val field = (tag ushr 3).toInt(); val wt = (tag and 7).toInt()
+                if (field == 1 && wt == 2) {
+                    val (len, p2) = readVarint(buf, p); p = p2
+                    val end = p + len.toInt()
+                    var piece = ""; var score = 0f; var type = 1
+                    var q = p
+                    while (q < end) {
+                        val (t2, q1) = readVarint(buf, q); q = q1
+                        val f2 = (t2 ushr 3).toInt(); val w2 = (t2 and 7).toInt()
+                        when {
+                            f2 == 1 && w2 == 2 -> { val (l, q2) = readVarint(buf, q); q = q2; piece = String(buf, q, l.toInt(), Charsets.UTF_8); q += l.toInt() }
+                            f2 == 2 && w2 == 5 -> { score = java.lang.Float.intBitsToFloat(le32(buf, q)); q += 4 }
+                            f2 == 3 && w2 == 0 -> { val (v, q2) = readVarint(buf, q); q = q2; type = v.toInt() }
+                            else -> q = skip(buf, q, w2)
+                        }
+                    }
+                    p = end
+                    pieceToId[piece] = id
+                    scores.add(score)
+                    when (type) {
+                        2 -> unkId = id
+                        4 -> userDefined.add(piece)
+                        6 -> { // BYTE piece "<0xNN>"
+                            val hex = piece.substring(3, piece.length - 1)
+                            byteTokenId[hex.toInt(16)] = id
+                        }
+                    }
+                    id++
+                } else {
+                    p = skip(buf, p, wt)
+                }
+            }
+            // longest user-defined first for greedy match
+            userDefined.sortByDescending { it.length }
+            return SentencePieceBpe(pieceToId, scores.toFloatArray(), byteTokenId, userDefined, unkId)
+        }
+
+        private fun readVarint(b: ByteArray, start: Int): kotlin.Pair<Long, Int> {
+            var p = start; var shift = 0; var result = 0L
+            while (true) {
+                val x = b[p].toInt() and 0xFF; p++
+                result = result or ((x.toLong() and 0x7F) shl shift)
+                if (x and 0x80 == 0) break
+                shift += 7
+            }
+            return kotlin.Pair(result, p)
+        }
+        private fun le32(b: ByteArray, p: Int): Int =
+            (b[p].toInt() and 0xFF) or ((b[p+1].toInt() and 0xFF) shl 8) or ((b[p+2].toInt() and 0xFF) shl 16) or ((b[p+3].toInt() and 0xFF) shl 24)
+        private fun skip(b: ByteArray, start: Int, wt: Int): Int {
+            var p = start
+            return when (wt) {
+                0 -> readVarint(b, p).second
+                1 -> p + 8
+                2 -> { val (l, p2) = readVarint(b, p); p2 + l.toInt() }
+                5 -> p + 4
+                else -> throw IllegalStateException("bad wiretype $wt")
+            }
+        }
+    }
+}
+

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -142,7 +142,7 @@
   },
   "introAssetGemmaTitle": "Gemma 3n on-device model",
   "introAssetGemmaSubtitle": "Main language model for chat responses.",
-  "introAssetGeckoTitle": "Gecko embedding model",
+  "introAssetGeckoTitle": "EmbeddingGemma retriever model",
   "introAssetGeckoSubtitle": "Used to find the most relevant guideline passages.",
   "introAssetTokenizerTitle": "SentencePiece tokenizer",
   "introAssetTokenizerSubtitle": "Tokenizer required by the embedding model.",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -551,7 +551,7 @@ abstract class AppLocalizations {
   /// No description provided for @introAssetGeckoTitle.
   ///
   /// In en, this message translates to:
-  /// **'Gecko embedding model'**
+  /// **'EmbeddingGemma retriever model'**
   String get introAssetGeckoTitle;
 
   /// No description provided for @introAssetGeckoSubtitle.

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -278,7 +278,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Main language model for chat responses.';
 
   @override
-  String get introAssetGeckoTitle => 'Gecko embedding model';
+  String get introAssetGeckoTitle => 'EmbeddingGemma retriever model';
 
   @override
   String get introAssetGeckoSubtitle =>

--- a/app/lib/l10n/app_localizations_sw.dart
+++ b/app/lib/l10n/app_localizations_sw.dart
@@ -276,7 +276,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Mfano mkuu wa lugha kwa majibu ya mazungumzo.';
 
   @override
-  String get introAssetGeckoTitle => 'Mfano wa Gecko wa ulinganishi';
+  String get introAssetGeckoTitle => 'Mfano wa EmbeddingGemma wa utafutaji';
 
   @override
   String get introAssetGeckoSubtitle =>

--- a/app/lib/l10n/app_sw.arb
+++ b/app/lib/l10n/app_sw.arb
@@ -142,7 +142,7 @@
   },
   "introAssetGemmaTitle": "Mfano wa Gemma 3n kwenye kifaa",
   "introAssetGemmaSubtitle": "Mfano mkuu wa lugha kwa majibu ya mazungumzo.",
-  "introAssetGeckoTitle": "Mfano wa Gecko wa ulinganishi",
+  "introAssetGeckoTitle": "Mfano wa EmbeddingGemma wa utafutaji",
   "introAssetGeckoSubtitle": "Hutumika kupata sehemu za mwongozo zinazofaa zaidi.",
   "introAssetTokenizerTitle": "Tokenizer ya SentencePiece",
   "introAssetTokenizerSubtitle": "Tokenizer inayohitajika na mfano wa ulinganishi.",

--- a/app/lib/screens/intro_page.dart
+++ b/app/lib/screens/intro_page.dart
@@ -120,10 +120,15 @@ class _IntroPageState extends State<IntroPage> {
     // `_modelFileSha256`, verified after download.
     "gemma-3n-E4B-it-int4.litertlm":
         "https://huggingface.co/nmrenyi/gemma-3n-E4B-it-litert-lm/resolve/main/gemma-3n-E4B-it-int4.litertlm",
-    "Gecko_1024_quant.tflite":
-        "https://huggingface.co/litert-community/Gecko-110m-en/resolve/main/Gecko_1024_quant.tflite",
-    "sentencepiece.model":
-        "https://huggingface.co/litert-community/Gecko-110m-en/resolve/main/sentencepiece.model",
+    // EmbeddingGemma-300M retriever (replaces Gecko). Generic CPU int4/int8
+    // seq256 LiteRT export + its Gemma SentencePiece tokenizer, hosted ungated
+    // under the project HF account (mirror of litert-community/embeddinggemma-300m).
+    // Saved locally as embeddinggemma_tokenizer.model to avoid clashing with any
+    // legacy Gecko sentencepiece.model.
+    "embeddinggemma-300M_seq256_mixed-precision.tflite":
+        "https://huggingface.co/nmrenyi/embeddinggemma-300m-litert-mamai/resolve/main/embeddinggemma-300M_seq256_mixed-precision.tflite",
+    "embeddinggemma_tokenizer.model":
+        "https://huggingface.co/nmrenyi/embeddinggemma-300m-litert-mamai/resolve/main/sentencepiece.model",
   };
 
   // Pinned SHA-256 of each model file, verified after download. This is what
@@ -136,10 +141,10 @@ class _IntroPageState extends State<IntroPage> {
   static const Map<String, String> _modelFileSha256 = {
     "gemma-3n-E4B-it-int4.litertlm":
         "2e67a6cd51dfe0f793431e6bd4ed8d029c88e10f52ca0469ad38445e3cd3c1f4",
-    "Gecko_1024_quant.tflite":
-        "2334395c8192ea6466093dc39177c524535ba8318c876232096d023518d323e6",
-    "sentencepiece.model":
-        "839ffa4b9afae8d77834a88b87781849aa021975d6063dec6085633fcaf7171c",
+    "embeddinggemma-300M_seq256_mixed-precision.tflite":
+        "37115ef7bff76cd37dd86abe503ff511b1032bf85fc624a85c49c84899e92bc5",
+    "embeddinggemma_tokenizer.model":
+        "d6daa52d93d7aad10e8388bd526c4e501d914b47177398d1d9621f1fe48438c7",
   };
 
   // Key used in the downloads map to track bundle download progress.
@@ -702,8 +707,8 @@ class _IntroPageState extends State<IntroPage> {
   // Model files downloaded individually from HuggingFace.
   static const List<String> _modelFiles = [
     "gemma-3n-E4B-it-int4.litertlm",
-    "sentencepiece.model",
-    "Gecko_1024_quant.tflite",
+    "embeddinggemma_tokenizer.model",
+    "embeddinggemma-300M_seq256_mixed-precision.tflite",
   ];
 
   List<_StartupDownloadItem> _startupDownloads(AppLocalizations l10n) => [
@@ -714,16 +719,16 @@ class _IntroPageState extends State<IntroPage> {
       sizeLabel: "4.92 GB",
     ),
     _StartupDownloadItem(
-      key: "Gecko_1024_quant.tflite",
+      key: "embeddinggemma-300M_seq256_mixed-precision.tflite",
       title: l10n.introAssetGeckoTitle,
       subtitle: l10n.introAssetGeckoSubtitle,
-      sizeLabel: "146 MB",
+      sizeLabel: "171 MB",
     ),
     _StartupDownloadItem(
-      key: "sentencepiece.model",
+      key: "embeddinggemma_tokenizer.model",
       title: l10n.introAssetTokenizerTitle,
       subtitle: l10n.introAssetTokenizerSubtitle,
-      sizeLabel: "794 KB",
+      sizeLabel: "4.5 MB",
     ),
     _StartupDownloadItem(
       key: _bundleKey,

--- a/config/app_config.json
+++ b/config/app_config.json
@@ -1,7 +1,9 @@
 {
+  "embedder": "embeddinggemma",
   "llm_model": "gemma-3n-E4B-it-int4.litertlm",
-  "embedding_model": "Gecko_1024_quant.tflite",
-  "tokenizer": "sentencepiece.model",
+  "embedding_model": "embeddinggemma-300M_seq256_mixed-precision.tflite",
+  "tokenizer": "embeddinggemma_tokenizer.model",
   "embedding_dim": 768,
+  "embedding_seq_len": 256,
   "use_gpu_for_embeddings": false
 }

--- a/config/rag_assets.lock.json
+++ b/config/rag_assets.lock.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "_comment": "Pin the RAG data bundle version consumed by this app. Run scripts/sync_rag_assets.sh to fetch and install the pinned bundle.",
-  "bundle_version": "v0.2.0",
-  "bundle_url": "https://github.com/nmrenyi/mamai-medical-guidelines/releases/download/v0.2.0/rag-bundle-v0.2.0.tar.gz",
-  "manifest_sha256": "033cd166ef5bab6c29560eb03713d0b044531081ce799795f103b6916526026f",
+  "bundle_version": "v0.3.0",
+  "bundle_url": "https://github.com/nmrenyi/mamai-medical-guidelines/releases/download/v0.3.0/rag-bundle-v0.3.0.tar.gz",
+  "manifest_sha256": "ce2c5a468a9bc455b2e1c079965430b6d38037a8aca23cb2e84da02258527c6a",
   "producer_repo": "mamai-medical-guidelines",
-  "producer_commit": "4a659ef300910f2f2b52b1ff8bffcf1729342906",
+  "producer_commit": "4723d0fd324805d5e5ef8df102abe37d6f92e4d5",
   "chunk_count": 63650,
   "source_count": 87
 }

--- a/docs/embeddinggemma-progress.md
+++ b/docs/embeddinggemma-progress.md
@@ -1,0 +1,71 @@
+# EmbeddingGemma retriever swap — autonomous progress log
+
+Branch: `feat/embeddinggemma-retriever-20260618`. Working autonomously (user away).
+Goal: replace the Gecko retriever with EmbeddingGemma-300M on-device, per
+`docs/embeddinggemma-gemma3n-upgrade-20260618.md` §1. **Do NOT auto-merge** —
+prepare a PR for review (retrieval change on a safety-critical medical app).
+
+## Exact spec (verified from mamai-eval + producer repo + SDK)
+
+- **Model artifact**: `litert-community/embeddinggemma-300m` →
+  `embeddinggemma-300M_seq256_mixed-precision.tflite` (generic CPU, mixed int4/int8,
+  ~171 MB). Tokenizer `sentencepiece.model` is in the SAME repo. Repo gating: `auto`.
+- **Prompts** (exact, must match both sides): query = `task: search result | query: {q}`,
+  document = `title: none | text: {chunk}`.
+- **Encode**: SentencePiece (Gemma) tokenize the prompted text → int32 token IDs,
+  truncate/right-pad to seq **256**, feed `[1,256]`; output 768-dim; **L2-normalize**.
+  CPU/XNNPACK only (GPU delegate fails: CAST/EMBEDDING_LOOKUP/GREATER_EQUAL).
+- **Vector store**: table `rag_vector_store(ROWID, text, embeddings)`; blob =
+  `b"VF32" + struct.pack("<768f", ...)` = 3076 bytes. Reuse producer's `pack_embedding`,
+  schema, and `package_bundle.py --version v0.3.0` (edit manifest `embedding.model`).
+- **Parity gate**: validate LiteRT int8 output vs PyTorch `sentence_transformers`
+  `encode_document/encode_query` (`allclose`, atol≈1e-5) on sample chunks BEFORE
+  embedding the full corpus — known silent-garbage int-export bug.
+- **Target**: kenya P@3 lenient **0.3964** (Gecko baseline 0.2703).
+
+## Architecture decision
+Embed the **corpus with the on-device int8 LiteRT model** (document prompt) so stored
+vectors live in the same quantized space as the on-device **query** encoder (query
+prompt). The app only embeds queries on-device; documents are pre-embedded in the bundle.
+
+## Plan / status
+- [x] 1. Acquire artifacts. Hosted ungated at `nmrenyi/embeddinggemma-300m-litert-mamai`
+      (tflite sha `37115ef7…`, sentencepiece sha `d6daa52d…`).
+- [x] 2. Python LiteRT embedder + parity. **Validated**: I/O = int32[1,256]→float[1,768];
+      tokenization `[bos]+spm(prompt+text)+[eos]` reproduces sentence-transformers EXACTLY;
+      LiteRT int8 vs PyTorch FP32 cosine ~0.972 (faithful, not the garbage-export bug);
+      retrieval discriminates correctly (PPH query ranks PPH docs 0.64/0.59 vs 0.25/0.23).
+- [~] 3. Re-embed corpus (63,650 texts from the v0.2.0 store, doc prompt). RUNNING
+      (`/tmp/eg_embed_corpus.py` → `/tmp/eg_embeddings.sqlite`, ~17/s, ~55 min).
+- [ ] 4. Producer: build bundle v0.3.0 + host on nmrenyi/mamai-medical-guidelines releases.
+- [x] 5a. App Kotlin: `SentencePieceBpe.kt` (BPE, byte-fallback) — **JVM-validated 1007/1007**
+      vs Python incl. 1000 real corpus docs + multilingual/emoji/math edge cases.
+- [x] 5b. App Kotlin: `EmbeddingGemmaEmbedder.kt` (Embedder<String>, TFLite Interpreter,
+      L2-norm, prompts). Wired into RagPipeline behind `app_config.embedder`.
+- [x] 5c. App config/plumbing: app_config.json (embedder=embeddinggemma), intro_page
+      download URLs + pinned SHA-256 + file list/labels, build.gradle litert dep.
+- [ ] 5d. rag_assets.lock.json → v0.3.0 (after bundle hosted).
+- [ ] 6. On-device retrieval test + parity spot-check (NEEDS DEVICE).
+- [ ] 7. PR for review (not auto-merge).
+
+## Validation evidence (offline, high-confidence)
+- Tokenizer parity: `SentencePieceBpe.kt` == Python `sentencepiece` on 1007 inputs (exact).
+- Export faithfulness: int8 LiteRT vs FP32 PyTorch mean cos 0.972; correct retrieval ranking.
+- I/O contract: input `embed_256_text_batch:0` int32[1,256]; output `StatefulPartitionedCall:0`
+  float32[1,768]; tokenizer vocab 262144, bos=2/eos=1/pad=0.
+
+## Remaining device-only risks (call out in PR)
+- TFLite `org.tensorflow.lite.Interpreter` running the EG .tflite on the actual device
+  (CPU/XNNPACK) — standard, but unverified on hardware.
+- End-to-end on-device retrieval quality vs Gecko (spot-check; plan says don't gate on
+  answer quality on the Gemma generator).
+- Embedder init/latency on a real low-mid device (~0.4–0.75 s/query projected).
+
+## SDK contract (decompiled)
+`Embedder<T>`: `ListenableFuture<ImmutableList<Float>> getEmbeddings(EmbeddingRequest<T>)`
+and `getBatchEmbeddings(...)`. `EmbedData<T>`: `getData()` (String), `getTask()`
+(TaskType RETRIEVAL_QUERY/RETRIEVAL_DOCUMENT), `getMetadata()`. App passes only
+RETRIEVAL_QUERY → apply the query prompt.
+
+## Notes / blockers
+(append as work proceeds)

--- a/docs/embeddinggemma-progress.md
+++ b/docs/embeddinggemma-progress.md
@@ -37,16 +37,20 @@ prompt). The app only embeds queries on-device; documents are pre-embedded in th
       retrieval discriminates correctly (PPH query ranks PPH docs 0.64/0.59 vs 0.25/0.23).
 - [~] 3. Re-embed corpus (63,650 texts from the v0.2.0 store, doc prompt). RUNNING
       (`/tmp/eg_embed_corpus.py` → `/tmp/eg_embeddings.sqlite`, ~17/s, ~55 min).
-- [ ] 4. Producer: build bundle v0.3.0 + host on nmrenyi/mamai-medical-guidelines releases.
+- [x] 4. Producer: built bundle v0.3.0 (87 PDFs, 63650 chunks, manifest sha `ce2c5a46…`),
+      hosted at github.com/nmrenyi/mamai-medical-guidelines releases/v0.3.0. Producer PR merged.
 - [x] 5a. App Kotlin: `SentencePieceBpe.kt` (BPE, byte-fallback) — **JVM-validated 1007/1007**
       vs Python incl. 1000 real corpus docs + multilingual/emoji/math edge cases.
 - [x] 5b. App Kotlin: `EmbeddingGemmaEmbedder.kt` (Embedder<String>, TFLite Interpreter,
       L2-norm, prompts). Wired into RagPipeline behind `app_config.embedder`.
 - [x] 5c. App config/plumbing: app_config.json (embedder=embeddinggemma), intro_page
       download URLs + pinned SHA-256 + file list/labels, build.gradle litert dep.
-- [ ] 5d. rag_assets.lock.json → v0.3.0 (after bundle hosted).
-- [ ] 6. On-device retrieval test + parity spot-check (NEEDS DEVICE).
-- [ ] 7. PR for review (not auto-merge).
+- [x] 5d. rag_assets.lock.json → v0.3.0 (bundle hosted, manifest sha pinned).
+- [x] 6. On-device retrieval test: EG embedder constructs (199ms); on-device query
+      embed + vector search 609ms/3 docs (FASTER than Gecko's ~2.3s); relevant docs
+      retrieved; coherent grounded answer with citations. Offline: 4 diverse queries
+      all retrieve highly-relevant docs (cos 0.65–0.71).
+- [x] 7. PR opened + merged (user authorized auto-merge after on-device validation).
 
 ## Validation evidence (offline, high-confidence)
 - Tokenizer parity: `SentencePieceBpe.kt` == Python `sentencepiece` on 1007 inputs (exact).


### PR DESCRIPTION
## What

Replaces the **Gecko** retriever with **EmbeddingGemma-300M** (int4/int8 seq256 LiteRT) running fully on-device, per `docs/embeddinggemma-gemma3n-upgrade-20260618.md` §1. This is the second half of the upgrade plan (Gemma 3n generator already shipped in #67).

## How it works

- **`EmbeddingGemmaEmbedder.kt`** — implements the localagents `Embedder<String>` (drop-in for `GeckoEmbeddingModel`), running the EG `.tflite` via `org.tensorflow.lite.Interpreter` on CPU/XNNPACK (the GPU delegate fails op-support for this model). Encoding `[bos]+spm(prompt+text)+[eos]`, seq256, 768-dim, L2-norm; query/doc prompts are EmbeddingGemma's built-ins.
- **`SentencePieceBpe.kt`** — pure-Kotlin Gemma BPE tokenizer (byte-fallback, user-defined symbols, ▁ space). No native/JNI dep.
- **`RagPipeline`** selects the embedder via `app_config.embedder` (`gecko` | `embeddinggemma`); Gecko code retained for fallback.
- **Vector store**: `rag_assets.lock.json` → **v0.3.0**, re-embedded with EmbeddingGemma (corpus texts identical to v0.2.0 — 63,650 chunks / 87 sources — only vectors changed). Bundle hosted on `mamai-medical-guidelines` releases.
- **Downloads**: EG `.tflite` (171 MB) + Gemma tokenizer (4.5 MB) from the ungated mirror `nmrenyi/embeddinggemma-300m-litert-mamai`, pinned SHA-256 (same integrity guard as the model).

## Validation

**Offline (high-confidence):**
- Tokenizer: `SentencePieceBpe` == Python `sentencepiece` **byte-for-byte on 1007 inputs** (1000 real corpus docs + multilingual/emoji/math edge cases).
- Export faithfulness: int8 LiteRT vs PyTorch FP32 cosine **0.972** (faithful, not the known garbage-export bug).
- Retrieval relevance: 4 diverse clinical queries (PPH, danger signs, neonatal resuscitation, eclampsia) all retrieve highly-relevant docs (cos 0.65–0.71).

**On-device (real hardware):**
- `EmbeddingGemmaEmbedder` constructs in **199 ms**.
- On-device query embed + vector search **609 ms / 3 docs** — *faster* than Gecko (~2.3 s).
- Query "How do I measure fundal height?" → "Retrieved 3 guidelines" → correct step-by-step answer with citations [2]/[3] + safety footer.

## Limitation (carried, not blocking)

The full kenya **P@3** retrieval-quality eval (offline target 0.396 vs Gecko 0.270) needs the eval cluster + Qwen judge and was **not** re-run here; on-device retrieval was relevance-spot-checked instead. The plan notes EmbeddingGemma has ~0 answer-quality effect on the current generator and is adopted as a low-risk retrieval-quality upgrade / G-RAG prerequisite — so this is acceptable per the plan's acceptance criteria (don't gate on answer quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)