### PR TITLE
chore: bump app version to 0.3.0+3

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.1.0+1
+version: 0.3.0+3
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Forward-hygiene version bump to match the `v0.3.0` release tag (EmbeddingGemma + Gemma 3n). The released APK version is derived from the git tag in release.yml; this keeps pubspec/local dev builds consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)