### PR TITLE
docs: refresh Gemma 4/Gecko → Gemma 3n + EmbeddingGemma

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,10 @@ The RAG pipeline (`RagPipeline.kt`) manages three main components:
    - CPU by default; GPU opt-in via `useGpuForLlm` Gradle property (see Backend Selection)
    - Max tokens: 4096
 
-2. **Embeddings**: Gecko embedding model for semantic search
-   - Model: `Gecko_1024_quant.tflite` (768-dim embeddings)
-   - Tokenizer: `sentencepiece.model`
-   - CPU by default (`use_gpu_for_embeddings: false` in `app_config.json`)
+2. **Embeddings**: EmbeddingGemma-300M for semantic search
+   - Model: `embeddinggemma-300M_seq256_mixed-precision.tflite` (int4/int8 seq256 LiteRT, 768-dim)
+   - Tokenizer: `embeddinggemma_tokenizer.model` (Gemma SentencePiece)
+   - Run on CPU/XNNPACK via a custom `EmbeddingGemmaEmbedder` (the GPU delegate fails op-support for this model). Selected by `"embedder": "embeddinggemma"` in `app_config.json`; the legacy Gecko path (`GeckoEmbeddingModel`) is retained as a config fallback.
 
 3. **Vector Store**: SQLite-backed semantic memory
    - Database: `embeddings.sqlite` (pre-computed document embeddings)
@@ -109,8 +109,8 @@ The RAG pipeline (`RagPipeline.kt`) manages three main components:
 
 Models are downloaded on first launch from HuggingFace and stored in `application.getExternalFilesDir(null)`:
 - `gemma-3n-E4B-it-int4.litertlm`: Gemma 3n E4B LLM (int4 quantized, 4.92 GB). Canonical source is `google/gemma-3n-E4B-it-litert-lm`, which is **license-gated** (401s the app's no-auth downloader), so the app downloads from `nmrenyi/gemma-3n-E4B-it-litert-lm` — a byte-identical, ungated copy under the project's own HF account (redistributed under the Gemma Terms of Use) — and verifies the file against a pinned SHA-256 (`_modelFileSha256` in `intro_page.dart`) to guarantee integrity.
-- `Gecko_1024_quant.tflite`: Gecko embedding model — `litert-community/Gecko-110m-en`
-- `sentencepiece.model`: Tokenizer — `litert-community/Gecko-110m-en`
+- `embeddinggemma-300M_seq256_mixed-precision.tflite`: EmbeddingGemma-300M retriever — `nmrenyi/embeddinggemma-300m-litert-mamai` (ungated mirror of gated `litert-community/embeddinggemma-300m`)
+- `embeddinggemma_tokenizer.model`: Gemma SentencePiece tokenizer — `nmrenyi/embeddinggemma-300m-litert-mamai`
 - `embeddings.sqlite`: Pre-computed document embeddings — mamai-medical-guidelines GitHub release
 
 Model download URLs are defined in `_modelFileUrls` in `app/lib/screens/intro_page.dart`. The pinned RAG bundle URL/version live in `config/rag_assets.lock.json`.
@@ -144,7 +144,7 @@ The RAG prompt is defined in `RagPipeline.kt:205-225`. It emphasizes:
 ### Backend Selection
 
 - **LLM**: defaults to CPU in production. Controlled by the `USE_GPU_FOR_LLM` `BuildConfig` field, set at compile time via the Gradle property `useGpuForLlm` (default `false`). If GPU init fails at runtime, `RagPipeline.kt` automatically falls back to CPU.
-- **Embeddings**: CPU by default (`use_gpu_for_embeddings: false` in `config/app_config.json`).
+- **Embeddings**: always CPU/XNNPACK. EmbeddingGemma's GPU delegate fails op-support, so `EmbeddingGemmaEmbedder` runs on CPU; the `use_gpu_for_embeddings` flag in `config/app_config.json` only affects the legacy Gecko fallback path.
 
 **To enable GPU locally** (e.g. for latency testing on a capable device), add to `~/.gradle/gradle.properties`:
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-Android app that answers clinical questions offline using on-device RAG — Gemma 4 E4B (LiteRT-LM) for generation, Gecko for embeddings, SQLite for vector search. No internet needed after the initial ~4.5 GB model download.
+Android app that answers clinical questions offline using on-device RAG — Gemma 3n E4B (LiteRT-LM) for generation, EmbeddingGemma-300M for embeddings, SQLite for vector search. No internet needed after the initial ~5 GB model download.
 
 ## Architecture
 
@@ -30,14 +30,14 @@ Android app that answers clinical questions offline using on-device RAG — Gemm
 │  ┌────────────────────────────────────────────┐ │
 │  │ RagPipeline.kt                             │ │
 │  │  ┌──────────┐ ┌──────────┐ ┌────────────┐ │ │
-│  │  │ Gemma 4  │ │  Gecko   │ │  SQLite    │ │ │
-│  │  │ LiteRT-LM│ │ Embedder │ │ VectorStore│ │ │
+│  │  │ Gemma 3n │ │ Embedding│ │  SQLite    │ │ │
+│  │  │ LiteRT-LM│ │ Gemma    │ │ VectorStore│ │ │
 │  │  └──────────┘ └──────────┘ └────────────┘ │ │
 │  └────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────┘
 ```
 
-Query → Gecko embeds → SQLite retrieves top-3 guideline chunks → prompt assembled → LiteRT-LM streams response → Flutter renders markdown.
+Query → EmbeddingGemma embeds → SQLite retrieves top-3 guideline chunks → prompt assembled → LiteRT-LM streams response → Flutter renders markdown.
 
 ## Build & Run
 
@@ -57,16 +57,20 @@ Download the APK from [Releases](../../releases) and sideload onto a real Androi
 
 ## Model Files
 
-Downloaded on first launch from public HuggingFace repos — no auth required.
+Downloaded on first launch — no auth required. Google's official Gemma 3n and
+EmbeddingGemma LiteRT repos are license-gated, so the app pulls byte-identical,
+ungated copies from the project's own HuggingFace account (redistributed under the
+Gemma Terms of Use) and verifies each file against a pinned SHA-256 before use.
 
 | File | Size | Source |
 |---|---|---|
-| `gemma-4-E4B-it.litertlm` | 3.65 GB | [litert-community/gemma-4-E4B-it-litert-lm](https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm) |
-| `Gecko_1024_quant.tflite` | 146 MB | [litert-community/Gecko-110m-en](https://huggingface.co/litert-community/Gecko-110m-en) |
-| `sentencepiece.model` | 794 KB | [litert-community/Gecko-110m-en](https://huggingface.co/litert-community/Gecko-110m-en) |
-| `embeddings.sqlite` | ~140 MB | [mamai-medical-guidelines releases](https://github.com/nmrenyi/mamai-medical-guidelines/releases) |
+| `gemma-3n-E4B-it-int4.litertlm` | 4.92 GB | [nmrenyi/gemma-3n-E4B-it-litert-lm](https://huggingface.co/nmrenyi/gemma-3n-E4B-it-litert-lm) (mirror of gated `google/gemma-3n-E4B-it-litert-lm`) |
+| `embeddinggemma-300M_seq256_mixed-precision.tflite` | 171 MB | [nmrenyi/embeddinggemma-300m-litert-mamai](https://huggingface.co/nmrenyi/embeddinggemma-300m-litert-mamai) (mirror of gated `litert-community/embeddinggemma-300m`) |
+| `embeddinggemma_tokenizer.model` | 4.5 MB | [nmrenyi/embeddinggemma-300m-litert-mamai](https://huggingface.co/nmrenyi/embeddinggemma-300m-litert-mamai) |
+| `embeddings.sqlite` | ~261 MB | [mamai-medical-guidelines releases](https://github.com/nmrenyi/mamai-medical-guidelines/releases) |
 
-The pinned RAG bundle version lives in `config/rag_assets.lock.json`.
+The pinned RAG bundle version lives in `config/rag_assets.lock.json`; the pinned
+model checksums live in `_modelFileSha256` in `app/lib/screens/intro_page.dart`.
 
 ## Updating RAG Assets
 
@@ -77,9 +81,9 @@ Chunking and embedding are managed in the companion [mamai-medical-guidelines](h
 
 ```bash
 bash scripts/sync_rag_assets.sh          # download + stage bundle
-bash scripts/sync_models.sh              # download Gecko + Gemma from HuggingFace
+bash scripts/sync_models.sh              # download EmbeddingGemma + Gemma 3n from HuggingFace
 bash scripts/push_to_device.sh           # push everything to connected device
-bash scripts/push_to_device.sh --embedding-models  # push Gecko + tokenizer only
+bash scripts/push_to_device.sh --embedding-models  # push embedder + tokenizer only
 ```
 
 ## Releasing
@@ -102,12 +106,16 @@ Benchmarks run across AfriMedQA, MedQA USMLE, MedMCQA, Kenya Vignettes, AfriMedQ
 | Model | MCQ avg | Open-ended avg |
 |---|---|---|
 | GPT-5 (no-RAG) | 82.8% | 4.19 / 5 |
-| Gemma 3n E4B (no-RAG) | 45.5% | 2.98 / 5 |
-| **Gemma 4 E4B (deployed, no-RAG)** | **42.9%** | **2.61 / 5** |
+| **Gemma 3n E4B (deployed, no-RAG)** | **45.5%** | **2.98 / 5** |
+| Gemma 4 E4B (previous deploy, no-RAG) | 42.9% | 2.61 / 5 |
 
-RAG slightly hurts both on-device models on MCQ; GPT-5 is unaffected.
+The deployed generator was swapped Gemma 4 E4B → **Gemma 3n E4B** (≈2× Kenya key-fact
+recall, +8 pp HealthBench completeness); the retriever was swapped Gecko →
+**EmbeddingGemma-300M**. RAG slightly hurts the on-device models on MCQ; GPT-5 is unaffected.
 
-On an OPPO Snapdragon 8 Elite device, Gemma 4 E4B averages **11.7 s TTFT**, **26.8 s total**, **13.8 tok/s** — slower TTFT than Gemma 3n E4B (6.8 s) despite faster decode.
+On an OPPO Snapdragon 8 Elite device, the deployed Gemma 3n E4B averages **~6.8 s TTFT**
+(vs Gemma 4 E4B's 11.7 s), with EmbeddingGemma query embedding + vector search around
+**0.5–0.6 s** (faster than Gecko's ~2.3 s).
 
 With LiteRT-LM 0.11.0 on GPU (opt-in), TTFT drops to ~1–2 s on the same device; decode rate is unchanged. Multi-token Prediction (`ExperimentalFlags.enableSpeculativeDecoding`, gated behind the `useMtpForLlm` Gradle property) was smoke-tested and produced a **~10–20% decode slowdown** rather than the vendor's claimed >2× — drafter acceptance is likely poor for our long retrieved-context prompts. Off by default; re-test before re-enabling.
 

--- a/device_push/README.md
+++ b/device_push/README.md
@@ -10,14 +10,13 @@ below).
 device_push/
 ├── bundle/     # sync-managed RAG assets — rm -rf bundle/ to wipe (gitignored)
 │   ├── embeddings.sqlite
-│   ├── docs/   # 55 source PDFs, normalized filenames
+│   ├── docs/   # 87 source PDFs, normalized filenames
 │   └── debug/  # provenance stamp + chunks_for_rag.txt
 ├── models/     # static ML model files, populated by sync_models.sh (gitignored)
-│   ├── Gecko_1024_quant.tflite
-│   ├── sentencepiece.model
-│   ├── gemma-4-E4B-it.litertlm
+│   ├── embeddinggemma-300M_seq256_mixed-precision.tflite
+│   ├── embeddinggemma_tokenizer.model
 │   ├── gemma-3n-E4B-it-int4.litertlm
-│   └── gemma-3n-E4B-it-int4.task
+│   └── (legacy: Gecko_1024_quant.tflite, gemma-4-E4B-it.litertlm — no longer used)
 ```
 
 `bundle/` is entirely owned by `sync_rag_assets.sh` — it is atomically rebuilt on every sync run, including its `debug/` provenance stamp. `models/` is never touched by the sync script. To wipe everything the sync produced: `rm -rf device_push/bundle/`.
@@ -27,17 +26,17 @@ device_push/
 ### Static ML models (populate via script or manual copy)
 | File | Format | Notes |
 |------|--------|-------|
-| `models/gemma-4-E4B-it.litertlm` | LiteRT-LM | Current deployed model |
-| `models/gemma-3n-E4B-it-int4.litertlm` | LiteRT-LM | Previous deployed model (quality baseline) |
-| `models/gemma-3n-E4B-it-int4.task` | MediaPipe | Kept for MediaPipe compatibility testing |
-| `models/Gecko_1024_quant.tflite` | TFLite | Embedding model |
-| `models/sentencepiece.model` | tokenizer | Tokenizer for Gecko |
+| `models/gemma-3n-E4B-it-int4.litertlm` | LiteRT-LM | Current deployed generator |
+| `models/embeddinggemma-300M_seq256_mixed-precision.tflite` | TFLite | Current deployed retriever (EmbeddingGemma-300M) |
+| `models/embeddinggemma_tokenizer.model` | tokenizer | Gemma SentencePiece for EmbeddingGemma |
+| `models/Gecko_1024_quant.tflite` | TFLite | Legacy embedder (no longer deployed) |
+| `models/gemma-4-E4B-it.litertlm` | LiteRT-LM | Legacy generator (no longer deployed) |
 
 ### RAG bundle assets (managed by sync script)
 | File | Source | Size |
 |------|--------|------|
-| `bundle/embeddings.sqlite` | pre-computed embeddings for 21,731 chunks | ~89 MB |
-| `bundle/docs/*.pdf` (55 files) | source medical guidelines, URL-safe names | ~91 MB |
+| `bundle/embeddings.sqlite` | EmbeddingGemma embeddings for 63,650 chunks | ~261 MB |
+| `bundle/docs/*.pdf` (87 files) | source medical guidelines, URL-safe names | ~430 MB |
 | `bundle/debug/rag_bundle_staged.json` | staged bundle provenance | small |
 
 PDF filenames use normalized SOURCE ids (spaces/parens → underscores, e.g.
@@ -69,8 +68,8 @@ transfer. To wipe the staged bundle entirely: `rm -rf device_push/bundle/`.
 # Download the public model artifacts into device_push/models/
 bash scripts/sync_models.sh
 
-# Optional: only fetch Gecko + tokenizer
-bash scripts/sync_models.sh --gecko-only
+# Optional: only fetch the EmbeddingGemma model + tokenizer (skip the large Gemma LLM)
+bash scripts/sync_models.sh --embedder-only
 ```
 
 ## Push to device
@@ -79,7 +78,7 @@ bash scripts/sync_models.sh --gecko-only
 # Push staged RAG assets (embeddings.sqlite + PDFs + provenance stamp)
 bash scripts/push_to_device.sh
 
-# Also push Gecko + sentencepiece.model
+# Also push the EmbeddingGemma model + tokenizer
 bash scripts/push_to_device.sh --embedding-models
 
 # If multiple devices are connected

--- a/scripts/push_to_device.sh
+++ b/scripts/push_to_device.sh
@@ -117,8 +117,8 @@ fi
 
 EMBEDDINGS_SQLITE="$DEVICE_PUSH/bundle/embeddings.sqlite"
 DOCS_DIR="$DEVICE_PUSH/bundle/docs"
-GECKO_MODEL="$DEVICE_PUSH/models/Gecko_1024_quant.tflite"
-TOKENIZER_MODEL="$DEVICE_PUSH/models/sentencepiece.model"
+EMBEDDER_MODEL="$DEVICE_PUSH/models/embeddinggemma-300M_seq256_mixed-precision.tflite"
+TOKENIZER_MODEL="$DEVICE_PUSH/models/embeddinggemma_tokenizer.model"
 
 if [[ ! -f "$EMBEDDINGS_SQLITE" ]]; then
     echo "ERROR: staged file missing: $EMBEDDINGS_SQLITE" >&2
@@ -142,8 +142,8 @@ if [[ "$DOC_COUNT" != "$LOCK_SOURCE_COUNT" ]]; then
 fi
 
 if [[ "$PUSH_EMBEDDING_MODELS" -eq 1 ]]; then
-    if [[ ! -f "$GECKO_MODEL" ]]; then
-        echo "ERROR: staged model missing: $GECKO_MODEL" >&2
+    if [[ ! -f "$EMBEDDER_MODEL" ]]; then
+        echo "ERROR: staged model missing: $EMBEDDER_MODEL" >&2
         exit 1
     fi
     if [[ ! -f "$TOKENIZER_MODEL" ]]; then
@@ -255,7 +255,7 @@ done
 MODEL_COUNT=0
 if [[ "$PUSH_EMBEDDING_MODELS" -eq 1 ]]; then
     echo "Pushing embedding model + tokenizer ..."
-    "$ADB_BIN" "${ADB_ARGS[@]}" push "$GECKO_MODEL" "$DEVICE_DIR/" >/dev/null
+    "$ADB_BIN" "${ADB_ARGS[@]}" push "$EMBEDDER_MODEL" "$DEVICE_DIR/" >/dev/null
     "$ADB_BIN" "${ADB_ARGS[@]}" push "$TOKENIZER_MODEL" "$DEVICE_DIR/" >/dev/null
     MODEL_COUNT=2
 fi

--- a/scripts/sync_models.sh
+++ b/scripts/sync_models.sh
@@ -2,21 +2,22 @@
 # sync_models.sh — Download AI model files from HuggingFace into device_push/models/
 #
 # Downloads:
-#   gemma-3n-E4B-it-int4.litertlm (4.92 GB) from nmrenyi/gemma-3n-E4B-it-litert-lm
-#   Gecko_1024_quant.tflite       (146 MB)  from litert-community/Gecko-110m-en
-#   sentencepiece.model           (794 KB)  from litert-community/Gecko-110m-en
+#   gemma-3n-E4B-it-int4.litertlm                     (4.92 GB) from nmrenyi/gemma-3n-E4B-it-litert-lm
+#   embeddinggemma-300M_seq256_mixed-precision.tflite (171 MB)  from nmrenyi/embeddinggemma-300m-litert-mamai
+#   embeddinggemma_tokenizer.model                    (4.5 MB)  from nmrenyi/embeddinggemma-300m-litert-mamai (sentencepiece.model)
 #
-# All public on HuggingFace — no token required. The Gemma 3n repo above is a
-# byte-identical, ungated copy of the (license-gated) official
-# google/gemma-3n-E4B-it-litert-lm, redistributed under the Gemma Terms of Use
-# so the app can fetch it without per-user gating. To validate against the
-# canonical gated repo instead, override the repo AND pass a token, e.g.:
+# All public on HuggingFace — no token required. Both nmrenyi repos are
+# byte-identical, ungated copies of the (license-gated) official
+# google/gemma-3n-E4B-it-litert-lm and litert-community/embeddinggemma-300m,
+# redistributed under the Gemma Terms of Use so the app can fetch them without
+# per-user gating. To validate against a canonical gated repo, override the repo
+# AND pass a token, e.g.:
 #   GEMMA_REPO=google/gemma-3n-E4B-it-litert-lm HF_TOKEN=hf_xxx scripts/sync_models.sh
 # Files already present are skipped (re-run is idempotent).
 #
 # Usage:
-#   scripts/sync_models.sh               # download all three files
-#   scripts/sync_models.sh --gecko-only  # skip Gemma, download only Gecko + tokenizer
+#   scripts/sync_models.sh                   # download all three files
+#   scripts/sync_models.sh --embedder-only   # skip the Gemma LLM, download only the embedder + tokenizer
 #
 # Requirements: curl
 
@@ -26,22 +27,22 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MODELS_DIR="$REPO_ROOT/device_push/models"
 
 HF="https://huggingface.co"
-GECKO_REPO="litert-community/Gecko-110m-en"
-# Overridable so maintainers can pull from the canonical gated repo with a token
-# (see header). Defaults to the project's ungated, byte-identical copy.
+# Overridable so maintainers can pull from a canonical gated repo with a token
+# (see header). Defaults to the project's ungated, byte-identical copies.
+EMBEDDER_REPO="${EMBEDDER_REPO:-nmrenyi/embeddinggemma-300m-litert-mamai}"
 GEMMA_REPO="${GEMMA_REPO:-nmrenyi/gemma-3n-E4B-it-litert-lm}"
 HF_TOKEN="${HF_TOKEN:-}"
 
-GECKO_ONLY=0
+EMBEDDER_ONLY=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --gecko-only)
-      GECKO_ONLY=1
+    --embedder-only)
+      EMBEDDER_ONLY=1
       shift
       ;;
     -h|--help)
-      awk 'NR >= 2 && NR <= 16 { sub(/^# ?/, ""); print }' "$0"
+      awk 'NR >= 2 && NR <= 22 { sub(/^# ?/, ""); print }' "$0"
       exit 0
       ;;
     *)
@@ -74,18 +75,20 @@ download_file() {
   echo "  -> $dest"
 }
 
-if [[ "$GECKO_ONLY" -eq 0 ]]; then
+if [[ "$EMBEDDER_ONLY" -eq 0 ]]; then
   download_file "gemma-3n-E4B-it-int4.litertlm" \
     "$HF/$GEMMA_REPO/resolve/main/gemma-3n-E4B-it-int4.litertlm"
 fi
 
-download_file "Gecko_1024_quant.tflite" \
-  "$HF/$GECKO_REPO/resolve/main/Gecko_1024_quant.tflite"
+download_file "embeddinggemma-300M_seq256_mixed-precision.tflite" \
+  "$HF/$EMBEDDER_REPO/resolve/main/embeddinggemma-300M_seq256_mixed-precision.tflite"
 
-download_file "sentencepiece.model" \
-  "$HF/$GECKO_REPO/resolve/main/sentencepiece.model"
+# The tokenizer asset is named sentencepiece.model upstream; stage it under the
+# distinct on-device filename the app expects (app_config.json "tokenizer").
+download_file "embeddinggemma_tokenizer.model" \
+  "$HF/$EMBEDDER_REPO/resolve/main/sentencepiece.model"
 
 echo ""
 echo "Models ready in $MODELS_DIR"
 echo "Next: bash scripts/push_to_device.sh --embedding-models"
-echo "Note: this pushes only Gecko + sentencepiece. The Gemma .litertlm is downloaded here for staging/verification and is fetched by the app on first launch."
+echo "Note: this pushes only the EmbeddingGemma model + tokenizer. The Gemma .litertlm is downloaded here for staging/verification and is fetched by the app on first launch."


### PR DESCRIPTION
Updates the user-facing docs + staging scripts that still described the pre-upgrade stack (Gemma 4 + Gecko) to match what `main` ships: **Gemma 3n** generator + **EmbeddingGemma-300M** retriever, RAG bundle **v0.3.0**.

- `README.md`, `CLAUDE.md`, `device_push/README.md`: architecture, model tables, download sources (ungated mirrors + pinned SHA-256), counts (87 PDFs / 63,650 chunks), eval/latency notes.
- `scripts/sync_models.sh` + `push_to_device.sh`: stage/push EmbeddingGemma model + tokenizer; `--gecko-only` → `--embedder-only`.
- Intentionally untouched: `evaluation/*` (legit comparison-model + historical runbook refs) and app-code comments describing Gecko as the legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)