### PR TITLE
fix(eval): drop dead Swahili prompt load that broke CI

### DIFF
--- a/evaluation/prompts.py
+++ b/evaluation/prompts.py
@@ -23,7 +23,6 @@ _evalcfg  = json.loads((_CONFIG_DIR / "eval_config.json").read_text())
 # --- App system prompt (single source of truth: config/prompts/system_en.txt) ---
 
 APP_SYSTEM_PROMPT: str = (_PROMPTS_DIR / "system_en.txt").read_text(encoding="utf-8").rstrip("\n")
-APP_SYSTEM_PROMPT_SW: str = (_PROMPTS_DIR / "system_sw.txt").read_text(encoding="utf-8").rstrip("\n")
 
 # --- MCQ adapter prompt ---
 # NOT the app prompt. Required because the app prompt produces clinical prose,


### PR DESCRIPTION
Follow-up to the English-only change (PR #71). The evaluation harness's `prompts.py` still loaded the now-deleted `config/prompts/system_sw.txt` at import, failing 5 `test_imports.py` tests on main. The `APP_SYSTEM_PROMPT_SW` symbol was never used and the tests only assert the English prompt, so the line is removed. All test_imports + scoring tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)