### PR TITLE
docs: expand README install section (direct + adb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,46 @@ adb logcat -s mam-ai     # timing, memory, inference logs
 ## Install
 
 MAM-AI ships as a signed Android APK (it is **not** on the Play Store). The APK is on the
-[Releases page](../../releases), named `mamai-<version>-<sha>-rag-<bundle>.apk`. Install it one of two ways:
+[Releases page](../../releases), named `mamai-<version>-<sha>-rag-<bundle>.apk`. Choose the method
+that fits the phone's connectivity:
 
-**Method 1 — directly on the phone (easiest for end users)**
-1. Open the [Releases page](../../releases) on the phone and download the latest `mamai-*.apk`.
-2. Tap the downloaded file. Android will ask permission to "install unknown apps" for your browser/Files app — enable it, then confirm the install.
+### Method 1 — install the APK, models download on first launch *(needs good internet on the phone)*
 
-**Method 2 — sideload from a computer via `adb`** (phone in Developer Mode with USB debugging on, connected by cable)
+1. On the phone, open the [Releases page](../../releases) and download the latest `mamai-*.apk`.
+2. Tap the downloaded file. When prompted, allow "install unknown apps" for your browser/Files app, then confirm the install.
+3. Open MAM-AI. On first launch it downloads the AI models + medical guidelines (**~4.5 GB, one-time**) over **Wi-Fi** — each file verified against a pinned SHA-256 — then runs fully offline.
+
+### Method 2 — fully offline sideload *(no internet on the phone)*
+
+For field devices with little or no connectivity. Stage the assets **once** on a computer with
+internet, then push the app **and every asset** to the phone over USB — it opens ready with **zero
+on-device downloads**. The phone needs USB debugging on (Settings → Developer options).
+
+Stage the assets (run from the repo root):
+
 ```bash
-adb install mamai-<version>-<sha>-rag-<bundle>.apk
-# upgrading in place? add -r:  adb install -r mamai-*.apk
+bash scripts/sync_models.sh        # Gemma 4 + EmbeddingGemma + tokenizer  → device_push/models/
+bash scripts/sync_rag_assets.sh    # pinned RAG bundle (embeddings + PDFs) → device_push/bundle/
 ```
 
-**Then, either way:** open MAM-AI. On first launch it downloads the AI models + medical guidelines (**~4.5 GB, one-time**) — keep the phone on **Wi-Fi** and plugged in. After that it runs **fully offline**; each downloaded file is verified against a pinned checksum.
+Build the signed APK:
+
+```bash
+cd app
+flutter build apk --release
+cd ..
+```
+
+Connect the phone by USB, then push the app + every asset:
+
+```bash
+bash scripts/push_to_device.sh --all-models --apk app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+`push_to_device.sh --all-models` installs the app and pushes the LLM, the EmbeddingGemma retriever +
+tokenizer (each with its `.verified` checksum marker), the vector store, and all source PDFs — after
+verifying every model against the app's pinned SHA-256. Open MAM-AI afterwards: it goes straight to
+the chat screen, no download. To provision more phones, repeat only the last command (offline) for each.
 
 **Requirements:** a real Android phone (Android 7.0 / API 24 or newer — emulators are unsupported; on-device inference needs real hardware), **~8 GB free storage**, and a recent mid-to-high-end device for acceptable response speed.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,24 @@ adb logcat -s mam-ai     # timing, memory, inference logs
 
 ## Install
 
-Download the APK from [Releases](../../releases) and sideload onto a real Android device.
+MAM-AI ships as a signed Android APK (it is **not** on the Play Store). The APK is on the
+[Releases page](../../releases), named `mamai-<version>-<sha>-rag-<bundle>.apk`. Install it one of two ways:
+
+**Method 1 — directly on the phone (easiest for end users)**
+1. Open the [Releases page](../../releases) on the phone and download the latest `mamai-*.apk`.
+2. Tap the downloaded file. Android will ask permission to "install unknown apps" for your browser/Files app — enable it, then confirm the install.
+
+**Method 2 — sideload from a computer via `adb`** (phone in Developer Mode with USB debugging on, connected by cable)
+```bash
+adb install mamai-<version>-<sha>-rag-<bundle>.apk
+# upgrading in place? add -r:  adb install -r mamai-*.apk
+```
+
+**Then, either way:** open MAM-AI. On first launch it downloads the AI models + medical guidelines (**~4.5 GB, one-time**) — keep the phone on **Wi-Fi** and plugged in. After that it runs **fully offline**; each downloaded file is verified against a pinned checksum.
+
+**Requirements:** a real Android phone (Android 7.0 / API 24 or newer — emulators are unsupported; on-device inference needs real hardware), **~8 GB free storage**, and a recent mid-to-high-end device for acceptable response speed.
+
+> Developers building from source: see [Build & Run](#build--run) above.
 
 ## Model Files
 

--- a/scripts/push_to_device.sh
+++ b/scripts/push_to_device.sh
@@ -7,9 +7,20 @@
 # After all pushes succeed, it writes rag_bundle_deployed.json on the device.
 #
 # Usage:
-#   scripts/push_to_device.sh
-#   scripts/push_to_device.sh --embedding-models
+#   scripts/push_to_device.sh                          # RAG bundle only (embeddings + PDFs)
+#   scripts/push_to_device.sh --embedding-models       # + EmbeddingGemma model + tokenizer (+ checksum markers)
+#   scripts/push_to_device.sh --all-models             # + the Gemma LLM too — FULL offline provision
+#   scripts/push_to_device.sh --all-models --apk app-release.apk   # also install the app
 #   scripts/push_to_device.sh --serial <device-id>
+#
+# FULLY OFFLINE INSTALL: `--all-models` (optionally with `--apk`) pushes every
+# asset the app needs — the LLM, the EmbeddingGemma retriever + tokenizer, the
+# vector store, the source PDFs — AND writes the per-model `.verified` checksum
+# markers the app requires. After it completes the app opens ready with ZERO
+# on-device downloads (no internet needed on the phone). Markers are written only
+# after the staged file's SHA-256 is confirmed against the pinned value in
+# app/lib/screens/intro_page.dart, so a wrong/corrupt staged file fails loudly
+# rather than provisioning a model the app would silently re-download.
 
 set -euo pipefail
 
@@ -26,8 +37,12 @@ DEPLOY_RECORD_NAME="rag_bundle_deployed.json"
 BUNDLE_READY_MARKER=".rag_bundle_ready"
 
 PUSH_EMBEDDING_MODELS=0
+PUSH_LLM=0
+APK_PATH=""
 SERIAL=""
 TMP_DIR=""
+APP_CONFIG="$REPO_ROOT/config/app_config.json"
+INTRO_PAGE="$REPO_ROOT/app/lib/screens/intro_page.dart"
 
 # ---------------------------------------------------------------------------
 # Parse args
@@ -43,6 +58,19 @@ while [[ $# -gt 0 ]]; do
             PUSH_EMBEDDING_MODELS=1
             shift
             ;;
+        --all-models)
+            PUSH_EMBEDDING_MODELS=1
+            PUSH_LLM=1
+            shift
+            ;;
+        --apk)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --apk requires a path to the .apk file." >&2
+                exit 1
+            fi
+            APK_PATH="$2"
+            shift 2
+            ;;
         --serial)
             if [[ $# -lt 2 ]]; then
                 echo "ERROR: --serial requires a device id." >&2
@@ -52,7 +80,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            awk 'NR >= 2 && NR <= 11 { sub(/^# ?/, ""); print }' "$0"
+            awk 'NR >= 2 && NR <= 27 { sub(/^# ?/, ""); print }' "$0"
             exit 0
             ;;
         *)
@@ -119,6 +147,10 @@ EMBEDDINGS_SQLITE="$DEVICE_PUSH/bundle/embeddings.sqlite"
 DOCS_DIR="$DEVICE_PUSH/bundle/docs"
 EMBEDDER_MODEL="$DEVICE_PUSH/models/embeddinggemma-300M_seq256_mixed-precision.tflite"
 TOKENIZER_MODEL="$DEVICE_PUSH/models/embeddinggemma_tokenizer.model"
+# LLM filename comes from the app config (single source of truth), so this script
+# stays correct across generator swaps (Gemma 3n/4/…).
+LLM_MODEL_NAME=$(python3 -c "import json; print(json.load(open('$APP_CONFIG'))['llm_model'])")
+LLM_MODEL="$DEVICE_PUSH/models/$LLM_MODEL_NAME"
 
 if [[ ! -f "$EMBEDDINGS_SQLITE" ]]; then
     echo "ERROR: staged file missing: $EMBEDDINGS_SQLITE" >&2
@@ -151,6 +183,52 @@ if [[ "$PUSH_EMBEDDING_MODELS" -eq 1 ]]; then
         exit 1
     fi
 fi
+
+if [[ "$PUSH_LLM" -eq 1 && ! -f "$LLM_MODEL" ]]; then
+    echo "ERROR: staged LLM missing: $LLM_MODEL" >&2
+    echo "Run: bash scripts/sync_models.sh" >&2
+    exit 1
+fi
+
+if [[ -n "$APK_PATH" && ! -f "$APK_PATH" ]]; then
+    echo "ERROR: --apk path not found: $APK_PATH" >&2
+    exit 1
+fi
+
+# Pinned SHA-256 for a model filename, read from intro_page.dart's
+# _modelFileSha256 (the app's source of truth). Empty if not pinned.
+pinned_sha_for() {
+    python3 - "$1" <<PY
+import re, sys
+name = sys.argv[1]
+text = open("$INTRO_PAGE").read()
+m = re.search(r"_modelFileSha256\s*=\s*\{(.*?)\}", text, re.S)
+pairs = dict(re.findall(r'"([^"]+)"\s*:\s*"([0-9a-f]{64})"', m.group(1))) if m else {}
+print(pairs.get(name, ""))
+PY
+}
+
+# Push a model file + its `.verified` marker. Verifies the staged file's SHA-256
+# against the app's pinned value first, so we never provision a model the app
+# would silently reject and re-download. Marker content = the pinned hash (what
+# the app's downloadsDone compares against).
+push_model_with_marker() {
+    local path="$1" name; name="$(basename "$1")"
+    local pinned actual
+    pinned="$(pinned_sha_for "$name")"
+    actual="$(shasum -a 256 "$path" | awk '{print $1}')"
+    if [[ -n "$pinned" && "$actual" != "$pinned" ]]; then
+        echo "ERROR: staged $name SHA-256 does not match the app's pinned value." >&2
+        echo "  staged : $actual" >&2
+        echo "  pinned : $pinned" >&2
+        echo "Re-stage with scripts/sync_models.sh (the staged file is wrong/corrupt)." >&2
+        exit 1
+    fi
+    echo "  $name ($actual)"
+    "$ADB_BIN" "${ADB_ARGS[@]}" push "$path" "$DEVICE_DIR/" >/dev/null
+    printf '%s' "$actual" > "$TMP_DIR/$name.verified"
+    "$ADB_BIN" "${ADB_ARGS[@]}" push "$TMP_DIR/$name.verified" "$DEVICE_DIR/$name.verified" >/dev/null
+}
 
 # ---------------------------------------------------------------------------
 # Resolve adb and connected device
@@ -209,6 +287,16 @@ echo "  Device dir     : $DEVICE_DIR"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Install the APK first (if requested), so the package + its data dir exist
+# ---------------------------------------------------------------------------
+
+if [[ -n "$APK_PATH" ]]; then
+    echo "Installing app: $APK_PATH"
+    "$ADB_BIN" "${ADB_ARGS[@]}" install -r "$APK_PATH"
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
 # Prepare deployment record and device target
 # ---------------------------------------------------------------------------
 
@@ -253,11 +341,16 @@ for pdf in "$DOCS_DIR"/*.pdf; do
 done
 
 MODEL_COUNT=0
+if [[ "$PUSH_LLM" -eq 1 ]]; then
+    echo "Pushing LLM + checksum marker ..."
+    push_model_with_marker "$LLM_MODEL"
+    MODEL_COUNT=$((MODEL_COUNT + 1))
+fi
 if [[ "$PUSH_EMBEDDING_MODELS" -eq 1 ]]; then
-    echo "Pushing embedding model + tokenizer ..."
-    "$ADB_BIN" "${ADB_ARGS[@]}" push "$EMBEDDER_MODEL" "$DEVICE_DIR/" >/dev/null
-    "$ADB_BIN" "${ADB_ARGS[@]}" push "$TOKENIZER_MODEL" "$DEVICE_DIR/" >/dev/null
-    MODEL_COUNT=2
+    echo "Pushing embedding model + tokenizer + checksum markers ..."
+    push_model_with_marker "$EMBEDDER_MODEL"
+    push_model_with_marker "$TOKENIZER_MODEL"
+    MODEL_COUNT=$((MODEL_COUNT + 2))
 fi
 
 echo "Writing deployment receipt ..."

--- a/scripts/sync_models.sh
+++ b/scripts/sync_models.sh
@@ -65,7 +65,9 @@ download_file() {
   echo "Downloading $filename ..."
   local auth=()
   [[ -n "$HF_TOKEN" ]] && auth=(-H "Authorization: Bearer $HF_TOKEN")
-  if ! curl -fL --show-error --retry 3 --retry-all-errors --progress-bar "${auth[@]}" -o "$dest.tmp" "$url"; then
+  # ${auth[@]+...} guards against "unbound variable" on bash 3.2 (macOS) under
+  # `set -u` when the array is empty (no HF_TOKEN — the common case).
+  if ! curl -fL --show-error --retry 3 --retry-all-errors --progress-bar ${auth[@]+"${auth[@]}"} -o "$dest.tmp" "$url"; then
     rm -f "$dest.tmp"
     return 1
   fi


### PR DESCRIPTION
Adds clear two-method install instructions before the v0.4.0 release: (1) download the signed APK from Releases on the phone, (2) `adb install` sideload from a computer — plus first-launch download/requirements notes.